### PR TITLE
Added stats and activity command for project resource

### DIFF
--- a/src/hdx_cli/cli_interface/common/rest_operations.py
+++ b/src/hdx_cli/cli_interface/common/rest_operations.py
@@ -13,7 +13,9 @@ from .cached_operations import *
 from .undecorated_click_commands import (basic_create,
                                          basic_delete,
                                          basic_list,
-                                         basic_show)
+                                         basic_show,
+                                         basic_activity,
+                                         basic_stats)
 
 
 @click.command(help='Create resource.')
@@ -107,3 +109,31 @@ def show(ctx: click.Context):
     profile = ctx.parent.obj['usercontext']
     print(basic_show(profile, resource_path,
                      resource_name))
+
+
+@click.command(help='Display the activity of a resource. If not resource_name is provided, it will show the default if '
+                    'there is one.')
+@click.option("-i", "--indent", type=int, help='Number of spaces for indentation in the output.')
+@click.pass_context
+@report_error_and_exit(exctype=Exception)
+def activity(ctx: click.Context, indent: int):
+    profile = ctx.parent.obj['usercontext']
+    _, resource_kind = _heuristically_get_resource_kind(ctx.parent.obj['resource_path'])
+    resource_name = getattr(profile, resource_kind + 'name')
+    resource_path = ctx.parent.obj['resource_path']
+    profile = ctx.parent.obj['usercontext']
+    print(basic_activity(profile, resource_path, resource_name, indent))
+
+
+@click.command(help='Display statistics for a resource. If not resource_name is provided, it will show the default if '
+                    'there is one.')
+@click.option("-i", "--indent", type=int, help='Number of spaces for indentation in the output.')
+@click.pass_context
+@report_error_and_exit(exctype=Exception)
+def stats(ctx: click.Context, indent: int):
+    profile = ctx.parent.obj['usercontext']
+    _, resource_kind = _heuristically_get_resource_kind(ctx.parent.obj['resource_path'])
+    resource_name = getattr(profile, resource_kind + 'name')
+    resource_path = ctx.parent.obj['resource_path']
+    profile = ctx.parent.obj['usercontext']
+    print(basic_stats(profile, resource_path, resource_name, indent))

--- a/src/hdx_cli/cli_interface/common/rest_operations.py
+++ b/src/hdx_cli/cli_interface/common/rest_operations.py
@@ -34,8 +34,8 @@ def create(ctx: click.Context,
            resource_name: str,
            body_from_file,
            body_from_file_type):
-    user_profile = ctx.parent.obj['usercontext']
-    resource_path = ctx.parent.obj['resource_path']
+    user_profile = ctx.parent.obj.get('usercontext')
+    resource_path = ctx.parent.obj.get('resource_path')
     basic_create(user_profile, resource_path,
                  resource_name, body_from_file, body_from_file_type)
     print(f'Created {resource_name}.')
@@ -45,6 +45,8 @@ _confirmation_prompt = partial(dynamic_confirmation_prompt,
                                prompt="Please type 'delete this resource' to delete: ",
                                confirmation_message='delete this resource',
                                fail_message='Incorrect prompt input: resource was not deleted')
+
+
 @click.command(help='Delete resource.')
 @click.option('--disable-confirmation-prompt',
               is_flag=True,
@@ -55,8 +57,8 @@ _confirmation_prompt = partial(dynamic_confirmation_prompt,
 def delete(ctx: click.Context, resource_name: str,
            disable_confirmation_prompt):
     _confirmation_prompt(prompt_active=not disable_confirmation_prompt)
-    resource_path = ctx.parent.obj['resource_path']
-    profile = ctx.parent.obj['usercontext']
+    resource_path = ctx.parent.obj.get('resource_path')
+    profile = ctx.parent.obj.get('usercontext')
     if basic_delete(profile, resource_path, resource_name):
         print(f'Deleted {resource_name}')
     else:
@@ -67,8 +69,8 @@ def delete(ctx: click.Context, resource_name: str,
 @click.pass_context
 @report_error_and_exit(exctype=Exception)
 def list_(ctx: click.Context):
-    resource_path = ctx.parent.obj['resource_path']
-    profile = ctx.parent.obj['usercontext']
+    resource_path = ctx.parent.obj.get('resource_path')
+    profile = ctx.parent.obj.get('usercontext')
     basic_list(profile, resource_path)
 
 
@@ -96,12 +98,10 @@ def _heuristically_get_resource_kind(resource_path) -> Tuple[str, str]:
 @click.pass_context
 @report_error_and_exit(exctype=Exception)
 def show(ctx: click.Context):
-    profile = ctx.parent.obj['usercontext']
-    _, resource_kind = _heuristically_get_resource_kind(ctx.parent.obj['resource_path'])
+    profile = ctx.parent.obj.get('usercontext')
+    resource_path = ctx.parent.obj.get('resource_path')
+    _, resource_kind = _heuristically_get_resource_kind(resource_path)
     resource_name = getattr(profile, resource_kind + 'name')
-
-    resource_path = ctx.parent.obj['resource_path']
-    profile = ctx.parent.obj['usercontext']
     print(basic_show(profile, resource_path,
                      resource_name))
 
@@ -112,11 +112,10 @@ def show(ctx: click.Context):
 @click.pass_context
 @report_error_and_exit(exctype=Exception)
 def activity(ctx: click.Context, indent: int):
-    profile = ctx.parent.obj['usercontext']
-    _, resource_kind = _heuristically_get_resource_kind(ctx.parent.obj['resource_path'])
+    profile = ctx.parent.obj.get('usercontext')
+    resource_path = ctx.parent.obj.get('resource_path')
+    _, resource_kind = _heuristically_get_resource_kind(resource_path)
     resource_name = getattr(profile, resource_kind + 'name')
-    resource_path = ctx.parent.obj['resource_path']
-    profile = ctx.parent.obj['usercontext']
     print(basic_activity(profile, resource_path, resource_name, indent))
 
 
@@ -126,9 +125,8 @@ def activity(ctx: click.Context, indent: int):
 @click.pass_context
 @report_error_and_exit(exctype=Exception)
 def stats(ctx: click.Context, indent: int):
-    profile = ctx.parent.obj['usercontext']
-    _, resource_kind = _heuristically_get_resource_kind(ctx.parent.obj['resource_path'])
+    profile = ctx.parent.obj.get('usercontext')
+    resource_path = ctx.parent.obj.get('resource_path')
+    _, resource_kind = _heuristically_get_resource_kind(resource_path)
     resource_name = getattr(profile, resource_kind + 'name')
-    resource_path = ctx.parent.obj['resource_path']
-    profile = ctx.parent.obj['usercontext']
     print(basic_stats(profile, resource_path, resource_name, indent))

--- a/src/hdx_cli/cli_interface/common/rest_operations.py
+++ b/src/hdx_cli/cli_interface/common/rest_operations.py
@@ -1,15 +1,9 @@
 from functools import partial
 from typing import Tuple
-import json
-
 import click
 
-from ...library_api.common.exceptions import (HdxCliException,
-                                              ResourceNotFoundException)
-from ...library_api.common import rest_operations as rest_ops
 from ...library_api.utility.decorators import (report_error_and_exit,
                                                dynamic_confirmation_prompt)
-from .cached_operations import *
 from .undecorated_click_commands import (basic_create,
                                          basic_delete,
                                          basic_list,
@@ -91,13 +85,14 @@ def _heuristically_get_resource_kind(resource_path) -> Tuple[str, str]:
     plural = split_path[-2]
     if plural == 'dictionaries':
         return 'dictionaries', 'dictionary'
-    elif plural == 'kinesis':
+    if plural == 'kinesis':
         return 'kinesis', 'kinesis'
     singular = plural if not plural.endswith('s') else plural[0:-1]
     return plural, singular
 
 
-@click.command(help='Show resource. If not resource_name is provided, it will show the default if there is one.')
+@click.command(help='Show resource. If not resource_name is provided, it will show the default '
+                    'if there is one.')
 @click.pass_context
 @report_error_and_exit(exctype=Exception)
 def show(ctx: click.Context):
@@ -111,8 +106,8 @@ def show(ctx: click.Context):
                      resource_name))
 
 
-@click.command(help='Display the activity of a resource. If not resource_name is provided, it will show the default if '
-                    'there is one.')
+@click.command(help='Display the activity of a resource. If not resource_name is provided, '
+                    'it will show the default if there is one.')
 @click.option("-i", "--indent", type=int, help='Number of spaces for indentation in the output.')
 @click.pass_context
 @report_error_and_exit(exctype=Exception)
@@ -125,8 +120,8 @@ def activity(ctx: click.Context, indent: int):
     print(basic_activity(profile, resource_path, resource_name, indent))
 
 
-@click.command(help='Display statistics for a resource. If not resource_name is provided, it will show the default if '
-                    'there is one.')
+@click.command(help='Display statistics for a resource. If not resource_name is provided, '
+                    'it will show the default if there is one.')
 @click.option("-i", "--indent", type=int, help='Number of spaces for indentation in the output.')
 @click.pass_context
 @report_error_and_exit(exctype=Exception)

--- a/src/hdx_cli/cli_interface/common/undecorated_click_commands.py
+++ b/src/hdx_cli/cli_interface/common/undecorated_click_commands.py
@@ -425,11 +425,10 @@ def _get_resource_information(profile,
             break
     if not url:
         raise ResourceNotFoundException(f'Resource "{resource_name}" not found.')
-    else:
-        url = url.replace('agustin-cli-2.hydro59.com', '35.88.46.67')
-        url += f'/{action}'
-        response = rest_ops.get(url, headers=headers)
-        return json.dumps(response, indent=indent)
+
+    url += f'/{action}'
+    response = rest_ops.get(url, headers=headers)
+    return json.dumps(response, indent=indent)
 
 
 def basic_stats(profile, resource_path, resource_name, indent):

--- a/src/hdx_cli/cli_interface/project/commands.py
+++ b/src/hdx_cli/cli_interface/project/commands.py
@@ -1,24 +1,13 @@
 """Commands relative to project resource."""
 import click
 
-from ..common import rest_operations as ro
 from ..common.undecorated_click_commands import basic_create
-
-from ...library_api.common.rest_operations import create
-from ...library_api.common.config_constants import HDX_CLI_HOME_DIR
-from ...library_api.common.dates import get_datetime_from_formatted_string
-from ...library_api.common.auth import AuthInfo, load_profile
-from ...library_api.common.context import ProfileLoadContext
-from ...library_api.common.exceptions import TokenExpiredException, HdxCliException
 from ...library_api.utility.decorators import report_error_and_exit
-
-
 from ..common.rest_operations import (delete as command_delete,
                                       list_ as command_list,
                                       show as command_show,
                                       activity as command_activity,
                                       stats as command_stats)
-
 from ..common.misc_operations import settings as command_settings
 
 

--- a/src/hdx_cli/cli_interface/project/commands.py
+++ b/src/hdx_cli/cli_interface/project/commands.py
@@ -15,7 +15,9 @@ from ...library_api.utility.decorators import report_error_and_exit
 
 from ..common.rest_operations import (delete as command_delete,
                                       list_ as command_list,
-                                      show as command_show)
+                                      show as command_show,
+                                      activity as command_activity,
+                                      stats as command_stats)
 
 from ..common.misc_operations import settings as command_settings
 
@@ -51,3 +53,5 @@ project.add_command(create)
 project.add_command(command_delete)
 project.add_command(command_show)
 project.add_command(command_settings)
+project.add_command(command_activity)
+project.add_command(command_stats)


### PR DESCRIPTION
Added two command for project resource. 
The first one is `stats`: this provides statistics information about a project.
e.g.:
`hdxcli --project hydro project stats`
`{"summary": {"name": "hydro", "total_partitions": 34, "total_rows": 24898, "total_data_size": 2370118, "total_storage_size": 4152496, "total_raw_data_size": 66059713}, "tables": [{"name": "hydro.monitor", "total_partitions": 0, "total_rows": 0, "total_data_size": 0, "total_storage_size": 0, "total_raw_data_size": 0}, {"name": "hydro.logs", "total_partitions": 34, "total_rows": 24898, "total_data_size": 2370118, "total_storage_size": 4152496, "total_raw_data_size": 66059713}]}`

The second is `activity`: this provides activity information about a project.
e.g.:
`hdxcli --project hydro project activity`
`{"next": 0, "previous": 0, "current": 1, "num_pages": 1, "count": 3, "results": [{"created": "2023-09-21T11:33:59.613646Z", "action": "publish:project", "org": null, "log": {"user": null, "action": {"type": "publish:project", "description": {"obj": {"type": "project", "uuid": "78d0f2ab-4ba9-42a1-ab80-69729a8d8e60", "snapshot": {"name": "hydro", "description": null}}, "text": "Published config"}}}}, {"created": "2023-09-21T11:33:54.785116Z", "action": "publish:project", "org": null, "log": {"user": null, "action": {"type": "publish:project", "description": {"obj": {"type": "project", "uuid": "78d0f2ab-4ba9-42a1-ab80-69729a8d8e60", "snapshot": {"name": "hydro", "description": null}}, "text": "Published config"}}}}, {"created": "2023-09-21T11:33:54.553362Z", "action": "create:project", "org": null, "log": {"user": null, "action": {"type": "create:project", "description": {"obj": {"type": "project", "uuid": "78d0f2ab-4ba9-42a1-ab80-69729a8d8e60", "snapshot": {"name": "hydro", "description": null}}, "text": "Created"}}}}]}`

In both cases you can add the `--indent` or `-i` option followed by an integer. This will cause the output to be indented.