### PR TITLE
Added pool command

### DIFF
--- a/src/hdx_cli/cli_interface/common/cached_operations.py
+++ b/src/hdx_cli/cli_interface/common/cached_operations.py
@@ -143,7 +143,7 @@ def find_pools(user_ctx: ProfileUserContext):
                "Accept": "application/json"}
     result = requests.get(url, headers=headers, timeout=30)
     if result.status_code != 200:
-        raise HdxCliException(f"Error getting storages.")
+        raise HdxCliException(f"Error getting pools.")
     return json.loads(result.content)
 
 

--- a/src/hdx_cli/cli_interface/common/cached_operations.py
+++ b/src/hdx_cli/cli_interface/common/cached_operations.py
@@ -134,6 +134,19 @@ def find_storages(user_ctx: ProfileUserContext):
     return json.loads(result.content)
 
 
+def find_pools(user_ctx: ProfileUserContext):
+    token = user_ctx.auth
+    hostname = user_ctx.hostname
+    scheme = user_ctx.scheme
+    url = f"{scheme}://{hostname}/config/v1/pools/"
+    headers = {"Authorization": f"{token.token_type} {token.token}",
+               "Accept": "application/json"}
+    result = requests.get(url, headers=headers, timeout=30)
+    if result.status_code != 200:
+        raise HdxCliException(f"Error getting storages.")
+    return json.loads(result.content)
+
+
 @find_in_disk_cache(cache_file=HDX_CLI_HOME_DIR / "cache/cache.bin",
                     namespace="transforms_ids")
 def find_transform_id(user_ctx, transform_name):

--- a/src/hdx_cli/cli_interface/pool/commands.py
+++ b/src/hdx_cli/cli_interface/pool/commands.py
@@ -1,6 +1,5 @@
 import click
 import json
-from functools import partial
 
 from ...library_api.utility.decorators import report_error_and_exit
 from ..common.rest_operations import delete as command_delete
@@ -8,7 +7,6 @@ from ..common.undecorated_click_commands import basic_settings
 from ..common.undecorated_click_commands import basic_create_with_body_from_string
 from ..common.rest_operations import (list_ as command_list,
                                       show as command_show)
-from ...library_api.common import rest_operations as rest_ops
 
 
 @click.group(help="Pool-related operations")

--- a/src/hdx_cli/cli_interface/pool/commands.py
+++ b/src/hdx_cli/cli_interface/pool/commands.py
@@ -1,0 +1,103 @@
+import click
+import json
+from functools import partial
+
+from ...library_api.utility.decorators import report_error_and_exit
+from ..common.rest_operations import delete as command_delete
+from ..common.undecorated_click_commands import basic_settings
+from ..common.undecorated_click_commands import basic_create_with_body_from_string
+from ..common.rest_operations import (list_ as command_list,
+                                      show as command_show)
+from ...library_api.common import rest_operations as rest_ops
+
+
+@click.group(help="Pool-related operations")
+@click.pass_context
+def pool(ctx: click.Context):
+    profile = ctx.parent.obj['usercontext']
+    ctx.obj = {'resource_path': f'/config/v1/pools/',
+               'usercontext': profile}
+
+
+def build_request_body(replicas, cpu, memory, storage, pool_service):
+    return {
+        'description': 'Created with hdxcli tool',
+        'settings': {
+            'k8s_deployment': {
+                'replicas': str(replicas),
+                'cpu': str(cpu),
+                'memory': f'{memory}Gi',
+                'storage': f'{storage}Gi',
+                'service': pool_service
+            }
+        }
+    }
+
+
+@click.command(help='Create new workload isolation resources')
+@click.option('--replicas', '-r',
+              type=int,
+              help='Number of replicas for the workload (default: 1)',
+              required=False,
+              default=1)
+@click.option('--cpu', '-c',
+              type=float,
+              help='Dedicated CPU allocation for each replica (default: 0.5)',
+              required=False,
+              default=0.5)
+@click.option('--memory', '-m',
+              type=float,
+              help='Dedicated memory allocation for each replica, expressed in Gi (default: 0.5)',
+              required=False,
+              default=0.5)
+@click.option('--storage', '-s',
+              type=float,
+              help='Storage capacity for each replica, expressed in Gi (default: 0.5)',
+              required=False,
+              default=0.5)
+@click.argument('pool_service')
+@click.argument('pool_name')
+@click.pass_context
+@report_error_and_exit(exctype=Exception)
+def create(ctx: click.Context,
+           replicas: int,
+           cpu: float,
+           memory: int,
+           storage: int,
+           pool_service: str,
+           pool_name: str):
+    user_profile = ctx.parent.obj.get('usercontext')
+    resource_path = ctx.parent.obj.get('resource_path')
+
+    body = build_request_body(replicas, cpu, memory, storage, pool_service)
+    basic_create_with_body_from_string(user_profile, resource_path, pool_name, json.dumps(body))
+    print(f'Created pool {pool_name}')
+
+
+@click.command(help="Get, set or list settings on a resource. When invoked with "
+               "only the key, it retrieves the value of the setting. If retrieved "
+               "with both key and value, the value for the key, if it exists, will "
+               "be set.\n"
+               "Otherwise, when invoked with no arguments, all the settings will be listed.")
+@click.argument("key", required=False, default=None)
+@click.argument("value", required=False, default=None)
+@click.pass_context
+@report_error_and_exit(exctype=Exception)
+def settings(ctx: click.Context,
+             key,
+             value):
+    resource_path = ctx.parent.obj.get("resource_path")
+    profile = ctx.parent.obj.get("usercontext")
+    the_value = value
+    if value:
+        the_value = value
+        if (stripped := value.strip()).startswith('[') and stripped.endswith(']'):
+            the_value = json.loads(stripped)
+    basic_settings(profile, resource_path, key, the_value)
+
+
+pool.add_command(command_list)
+pool.add_command(create)
+pool.add_command(command_delete)
+pool.add_command(command_show)
+pool.add_command(settings)

--- a/src/hdx_cli/cli_interface/set/commands.py
+++ b/src/hdx_cli/cli_interface/set/commands.py
@@ -19,7 +19,7 @@ def _serialize_to_config_file(profile: ProfileUserContext,
         toml.dump(all_profiles, stream)
 
 
-@click.command(help='Set project and or/table to apply subsequent commands on it')
+@click.command(help='Set project and/or table to apply subsequent commands on it')
 @click.argument('projectname', metavar='PROJECT_NAME', required=False, default=None)
 @click.argument('tablename', metavar='TABLE_NAME', required=False, default=None)
 @click.pass_context
@@ -43,7 +43,7 @@ def set(ctx, projectname, tablename, scheme=None):
     print(f"Profile '{profile.profilename}' set project/table")
 
 
-@click.command(help='Remove any set projects/tables')
+@click.command(help='Remove any set project/table')
 @click.pass_context
 def unset(ctx):
     profile: ProfileUserContext = ctx.obj['usercontext']

--- a/src/hdx_cli/main.py
+++ b/src/hdx_cli/main.py
@@ -22,6 +22,7 @@ from hdx_cli.cli_interface.profile import commands as profile_
 from hdx_cli.cli_interface.sources import commands as sources_
 from hdx_cli.cli_interface.migrate import commands as migrate_
 from hdx_cli.cli_interface.integration import commands as integration_
+from hdx_cli.cli_interface.pool import commands as pool_
 
 from hdx_cli.library_api.utility.decorators import report_error_and_exit
 from hdx_cli.library_api.common.validation import is_valid_username, is_valid_hostname
@@ -144,9 +145,11 @@ def fail_if_token_expired(user_context: ProfileUserContext):
 @click.option('--profile-config-file', hidden=True, help='Used only for testing.',
               default=None)
 @click.option('--storage', help='Perform operation on the passed storage.',
-              default=None)
+              metavar='STORAGENAME', default=None)
 @click.option('--source', help='Source for kinesis/kafka/summary/SIEM streams.',
-              default=None)
+              metavar='SOURCENAME', default=None)
+@click.option('--pool', help='Perform operation on the passed pool.',
+              metavar='POOLNAME', default=None)
 @click.option('--uri-scheme',
               help='Scheme used.',
               type=click.Choice(['default', 'http', 'https']),
@@ -165,6 +168,7 @@ def hdx_cli(ctx, profile,
             profile_config_file,
             storage,
             source,
+            pool,
             uri_scheme):
     "Command-line entry point for hdx cli interface"
     if ctx.invoked_subcommand == 'version':
@@ -227,6 +231,8 @@ def hdx_cli(ctx, profile,
         user_context.kinesisname = source
         user_context.siemname = source
         user_context.summaryname = source
+    if pool:
+        user_context.poolname = pool
     # Unconditional default override
     ctx.obj = {'usercontext': user_context}
 
@@ -251,6 +257,7 @@ hdx_cli.add_command(profile_.profile)
 hdx_cli.add_command(sources_.sources)
 hdx_cli.add_command(migrate_.migrate)
 hdx_cli.add_command(integration_.integration)
+hdx_cli.add_command(pool_.pool)
 hdx_cli.add_command(version)
 
 


### PR DESCRIPTION
Added pool command with typical verbs. Its use is as follows:
- `hdxcli pool list`
- `hdxcli pool create <service-name> <pool-name> [options]`
- `hdxcli pool delete <pool-name>`
- `hdxcli --pool <pool-name> pool show [options]`
- `hdxcli --pool <pool-name> pool settings`
