### PR TITLE
[QE-67]CI: Add the left-off envar to the Github Action files

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -19,6 +19,7 @@ jobs:
       - name: "Run tests"
         run: poetry run python3 -m pytest -v
         env:
+          tests_protocol : "http"
           HDXCLI_TESTS_CLUSTER_PASSWORD: ${{secrets.HDXCLI_TESTS_CLUSTER_PASSWORD}}
           HDXCLI_TESTS_CLUSTER_USERNAME: ${{secrets.HDXCLI_TESTS_CLUSTER_USERNAME}}
           PYTHONPATH: ${{env.PYTHONPATH}}

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -19,7 +19,7 @@ jobs:
       - name: "Run tests"
         run: poetry run python3 -m pytest -v
         env:
-          tests_protocol : "http"
+          HDXCLI_TESTS_CLUSTER_SSL_ACTIVE: ${{secrets.HDXCLI_TESTS_CLUSTER_SSL_ACTIVE}}
           HDXCLI_TESTS_CLUSTER_PASSWORD: ${{secrets.HDXCLI_TESTS_CLUSTER_PASSWORD}}
           HDXCLI_TESTS_CLUSTER_USERNAME: ${{secrets.HDXCLI_TESTS_CLUSTER_USERNAME}}
           PYTHONPATH: ${{env.PYTHONPATH}}


### PR DESCRIPTION
To get the CI working we need to add another envar to the yml file that controls the run