### PR TITLE
Updated migration process for summary tables linked across projects

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ maintainers = [
 
 [tool.poetry]
 name = "hdxcli"
-version = "1.0-rc44"
+version = "1.0-rc45"
 description = "Hydrolix command line utility to do CRUD operations on projects, tables, transforms and other resources in Hydrolix clusters"
 authors = ["German Diago Gomez <german@hydrolix.io>", "Agustin Actis <agustin@hydrolix.io>"]
 license = "MIT license"

--- a/src/hdx_cli/cli_interface/migrate/rollback.py
+++ b/src/hdx_cli/cli_interface/migrate/rollback.py
@@ -12,6 +12,7 @@ from ...library_api.common.context import ProfileUserContext
 class MigrateStatus(Enum):
     CREATED = 0
     SKIPPED = 1
+    POSTPONED = 2
 
 
 class ResourceKind(Enum):
@@ -20,6 +21,7 @@ class ResourceKind(Enum):
     TRANSFORM = 2
     FUNCTION = 3
     DICTIONARY = 4
+
 
 @dataclass(frozen=True)
 class MigrationEntry:

--- a/src/hdx_cli/main.py
+++ b/src/hdx_cli/main.py
@@ -30,7 +30,7 @@ from hdx_cli.library_api.common.first_use import try_first_time_use
 from hdx_cli.library_api.common.profile import save_profile, get_profile_data_from_standard_input
 
 
-VERSION = "1.0-rc44"
+VERSION = "1.0-rc45"
 
 
 from hdx_cli.library_api.common.auth import (

--- a/tests/command_line_interface/test_cases/test_read_only_flows.ts
+++ b/tests/command_line_interface/test_cases/test_read_only_flows.ts
@@ -41,7 +41,7 @@ global_setup = ["python3 -m hdx_cli.main project create test_ci_project",
                 ]
 
 global_teardown = ["python3 -m hdx_cli.main storage delete --disable-confirmation-prompt test_ci_storage",
-                   #"python3 -m hdx_cli.main project delete --disable-confirmation-prompt test_ci_project",
+                   "python3 -m hdx_cli.main project delete --disable-confirmation-prompt test_ci_project",
                    "python3 -m hdx_cli.main unset"]
 
 
@@ -171,7 +171,7 @@ expected_output_expr = 'not result.startswith("Error:") and "name" in result and
 name = "Summary (stream) tables can be created"
 setup = ["python3 -m hdx_cli.main unset"]
 commands_under_test = ["python3 -m hdx_cli.main table --project test_ci_project create -t summary -f {HDXCLI_TESTS_DIR}/tests_data/summary/stream/sql.txt test_summary_table_stream"]
-#teardown = ["python3 -m hdx_cli.main table --project test_ci_project delete --disable-confirmation-prompt test_summary_table_stream"]
+teardown = ["python3 -m hdx_cli.main table --project test_ci_project delete --disable-confirmation-prompt test_summary_table_stream"]
 expected_output = 'Created table test_summary_table_stream'
 
 [[test]]


### PR DESCRIPTION
Changed the migration process when summary tables are linked to regular tables in different projects. 
This modification addresses an issue where the migration process would fail in such scenarios
