### PR TITLE
Added migration command for individual resources

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ maintainers = [
 
 [tool.poetry]
 name = "hdxcli"
-version = "1.0-rc47"
+version = "1.0-rc48"
 description = "Hydrolix command line utility to do CRUD operations on projects, tables, transforms and other resources in Hydrolix clusters"
 authors = ["German Diago Gomez <german@hydrolix.io>", "Agustin Actis <agustin@hydrolix.io>"]
 license = "MIT license"

--- a/src/hdx_cli/cli_interface/common/migration.py
+++ b/src/hdx_cli/cli_interface/common/migration.py
@@ -1,0 +1,301 @@
+import os
+import io
+from pathlib import Path
+
+import tempfile
+from urllib.parse import urlparse
+import toml
+
+from ...library_api.common.auth_utils import load_user_context
+from ...library_api.common.context import ProfileLoadContext, ProfileUserContext
+from ...library_api.common.exceptions import HttpException
+from ...library_api.common import rest_operations as lro
+from ...library_api.common.login import login
+from ...library_api.common.auth import load_profile, save_profile_cache
+from ...library_api.common.generic_resource import access_resource_detailed
+from ...library_api.common.config_constants import PROFILE_CONFIG_FILE
+from ..common.undecorated_click_commands import basic_create_from_dict_body
+
+
+def _setup_target_cluster_config(profile_config_file,
+                                 target_cluster_username,
+                                 target_cluster_hostname,
+                                 target_cluster_scheme):
+    username = target_cluster_username
+    hostname = target_cluster_hostname
+    scheme = target_cluster_scheme
+    config_data = {'default': {'username': username, 'hostname': hostname, 'scheme': scheme}}
+    os.makedirs(Path(profile_config_file).parent, exist_ok=True)
+    with open(profile_config_file, 'w+', encoding='utf-8') as config_file:
+        toml.dump(config_data, config_file)
+
+
+def generate_target_profile(target_cluster_hostname,
+                            target_cluster_username,
+                            target_cluster_password,
+                            target_cluster_uri_scheme):
+    target_profiles_file = Path(tempfile.gettempdir() + os.sep +
+                                target_cluster_username + '_' +
+                                target_cluster_hostname + '.toml')
+    _setup_target_cluster_config(target_profiles_file,
+                                 target_cluster_username,
+                                 target_cluster_hostname,
+                                 target_cluster_uri_scheme)
+    target_load_ctx = ProfileLoadContext('default', target_profiles_file)
+    auth_info = login(target_cluster_username,
+                      target_cluster_hostname,
+                      password=target_cluster_password,
+                      use_ssl=(target_cluster_uri_scheme == 'https'))
+    target_profile = load_profile(target_load_ctx)
+    target_profile.auth = auth_info
+    target_profile.org_id = auth_info.org_id
+
+    save_profile_cache(target_profile,
+                       token=target_profile.auth.token,
+                       org_id=target_profile.org_id,
+                       token_type='Bearer',
+                       expiration_time=target_profile.auth.expires_at,
+                       cache_dir_path=target_profile.profile_config_file.parent)
+    return target_profile
+
+
+def migrate_a_project(source_profile,
+                      project_name,
+                      target_profile_name,
+                      target_cluster_hostname,
+                      target_cluster_username,
+                      target_cluster_password,
+                      target_cluster_uri_scheme):
+    target_profile = get_target_profile(target_profile_name,
+                                        target_cluster_hostname,
+                                        target_cluster_username,
+                                        target_cluster_password,
+                                        target_cluster_uri_scheme,
+                                        source_profile.timeout)
+
+    source_project_body, _ = access_resource_detailed(source_profile, [('projects', project_name)])
+    _, target_projects_url = access_resource_detailed(target_profile, [('projects', None)])
+    target_projects_path = urlparse(target_projects_url).path
+
+    # Deleting invalid keys for table creation.
+    remove_keys(source_project_body, 'uuid')
+    # Creating resource on target cluster.
+    basic_create_from_dict_body(target_profile, target_projects_path, source_project_body)
+
+
+def migrate_a_table(source_profile,
+                    table_name,
+                    target_profile_name,
+                    target_cluster_hostname,
+                    target_cluster_username,
+                    target_cluster_password,
+                    target_cluster_uri_scheme,
+                    target_project_name):
+    target_profile = get_target_profile(target_profile_name,
+                                        target_cluster_hostname,
+                                        target_cluster_username,
+                                        target_cluster_password,
+                                        target_cluster_uri_scheme,
+                                        source_profile.timeout)
+
+    source_table_body, _ = access_resource_detailed(source_profile,
+                                                    [('projects', source_profile.projectname),
+                                                     ('tables', table_name)])
+    _, target_tables_url = access_resource_detailed(target_profile,
+                                                    [('projects', target_project_name),
+                                                     ('tables', None)])
+    target_tables_path = urlparse(target_tables_url).path
+
+    remove_keys(source_table_body, 'uuid', ('settings', 'autoingest', 0, 'source'))
+    basic_create_from_dict_body(target_profile, target_tables_path, source_table_body)
+
+
+def migrate_a_transform(source_profile,
+                        transform_name,
+                        target_profile_name,
+                        target_cluster_hostname,
+                        target_cluster_username,
+                        target_cluster_password,
+                        target_cluster_uri_scheme,
+                        target_project_name,
+                        target_table_name):
+    target_profile = get_target_profile(target_profile_name,
+                                        target_cluster_hostname,
+                                        target_cluster_username,
+                                        target_cluster_password,
+                                        target_cluster_uri_scheme,
+                                        source_profile.timeout)
+
+    source_transform_body, _ = access_resource_detailed(source_profile,
+                                                        [('projects', source_profile.projectname),
+                                                         ('tables', source_profile.tablename),
+                                                         ('transforms', transform_name)])
+    _, target_transforms_url = access_resource_detailed(target_profile,
+                                                        [('projects', target_project_name),
+                                                         ('tables', target_table_name),
+                                                         ('transforms', None)])
+    target_transforms_path = urlparse(target_transforms_url).path
+
+    remove_keys(source_transform_body, 'uuid')
+    basic_create_from_dict_body(target_profile, target_transforms_path, source_transform_body)
+
+
+def migrate_a_dictionary(source_profile,
+                         dictionary_name,
+                         target_profile_name,
+                         target_cluster_hostname,
+                         target_cluster_username,
+                         target_cluster_password,
+                         target_cluster_uri_scheme,
+                         target_project_name):
+    target_profile = get_target_profile(target_profile_name,
+                                        target_cluster_hostname,
+                                        target_cluster_username,
+                                        target_cluster_password,
+                                        target_cluster_uri_scheme,
+                                        source_profile.timeout)
+
+    source_dictionaries_body, _ = access_resource_detailed(source_profile,
+                                                           [('projects', source_profile.projectname),
+                                                            ('dictionaries', dictionary_name)])
+    _, target_dictionaries_url = access_resource_detailed(target_profile,
+                                                          [('projects', target_project_name),
+                                                           ('dictionaries', None)])
+    target_dictionaries_path = urlparse(target_dictionaries_url).path
+
+    _migrate_dict_file(source_profile, target_profile, source_dictionaries_body,
+                       source_profile.projectname, target_project_name)
+
+    remove_keys(source_dictionaries_body, 'uuid')
+    basic_create_from_dict_body(target_profile, target_dictionaries_path, source_dictionaries_body)
+
+
+def migrate_a_function(source_profile,
+                       function_name,
+                       target_profile_name,
+                       target_cluster_hostname,
+                       target_cluster_username,
+                       target_cluster_password,
+                       target_cluster_uri_scheme,
+                       target_project_name):
+    target_profile = get_target_profile(target_profile_name,
+                                        target_cluster_hostname,
+                                        target_cluster_username,
+                                        target_cluster_password,
+                                        target_cluster_uri_scheme,
+                                        source_profile.timeout)
+
+    source_function_body, _ = access_resource_detailed(source_profile,
+                                                       [('projects', source_profile.projectname),
+                                                        ('functions', function_name)])
+    _, target_functions_url = access_resource_detailed(target_profile,
+                                                       [('projects', target_project_name),
+                                                        ('functions', None)])
+    target_functions_path = urlparse(target_functions_url).path
+
+    remove_keys(source_function_body, 'uuid')
+    basic_create_from_dict_body(target_profile, target_functions_path, source_function_body)
+
+
+def migrate_a_storage(source_profile,
+                      storage_name,
+                      target_profile_name,
+                      target_cluster_hostname,
+                      target_cluster_username,
+                      target_cluster_password,
+                      target_cluster_uri_scheme):
+    target_profile = get_target_profile(target_profile_name,
+                                        target_cluster_hostname,
+                                        target_cluster_username,
+                                        target_cluster_password,
+                                        target_cluster_uri_scheme,
+                                        source_profile.timeout)
+
+    source_storages_body, _ = access_resource_detailed(source_profile,
+                                                       [('storages', storage_name)])
+    _, target_storages_url = access_resource_detailed(target_profile,
+                                                      [('storages', None)])
+    target_storages_path = urlparse(target_storages_url).path
+
+    remove_keys(source_storages_body, 'uuid')
+    basic_create_from_dict_body(target_profile, target_storages_path, source_storages_body)
+
+
+def get_target_profile(target_profile_name,
+                       target_cluster_hostname,
+                       target_cluster_username,
+                       target_cluster_password,
+                       target_cluster_uri_scheme,
+                       target_timeout):
+    if target_profile_name:
+        load_context = ProfileLoadContext(target_profile_name, PROFILE_CONFIG_FILE)
+        target_profile = load_user_context(load_context)
+    else:
+        target_profile = generate_target_profile(target_cluster_hostname,
+                                                 target_cluster_username,
+                                                 target_cluster_password,
+                                                 target_cluster_uri_scheme)
+    target_profile.timeout = target_timeout
+    return target_profile
+
+
+def _migrate_dict_file(source_profile, target_profile, dictionary, source_project_name, target_project_name):
+    d_settings = dictionary['settings']
+    d_name = dictionary['name']
+    d_file = d_settings['filename']
+    d_format = d_settings['format']
+    table_name = f'{source_project_name}_{d_name}'
+    query_endpoint = (f'{source_profile.scheme}://{source_profile.hostname}'
+                      f'/query/?query=SELECT * FROM {table_name} FORMAT {d_format}')
+    headers = {'Authorization': f'{source_profile.auth.token_type} {source_profile.auth.token}',
+               'Accept': '*/*'}
+    timeout = source_profile.timeout
+    contents = lro.get(query_endpoint, headers=headers, timeout=timeout, fmt='verbatim')
+    try:
+        _create_dictionary_file_for_project(target_project_name, d_file, contents,
+                                            target_profile)
+    except HttpException:
+        # Dictionary file existed, no need to create it
+        pass
+
+
+def _create_dictionary_file_for_project(project_name,
+                                        dict_file,
+                                        contents,
+                                        profile: ProfileUserContext):
+    _, project_url = access_resource_detailed(profile,
+                                              [('projects', project_name)])
+
+    headers = {'Authorization': f'{profile.auth.token_type} {profile.auth.token}',
+               'Accept': '*/*'}
+    file_url = f'{project_url}dictionaries/files/'
+    timeout = profile.timeout
+    lro.create_file(file_url, headers=headers,
+                    file_stream=io.BytesIO(contents),
+                    remote_filename=dict_file,
+                    timeout=timeout)
+
+
+def remove_keys(resource, *args):
+    for key in args:
+        if isinstance(key, tuple):
+            current_level = resource
+            for nested_key in key[:-1]:
+                if (isinstance(current_level, list) and isinstance(nested_key, int)
+                        and 0 <= nested_key < len(current_level)):
+                    current_level = current_level[nested_key]
+                elif nested_key in current_level:
+                    current_level = current_level[nested_key]
+                else:
+                    # If any of the nested keys doesn't exist, simply return without doing anything.
+                    return
+
+            last_key = key[-1]
+            if (isinstance(current_level, list) and isinstance(last_key, int)
+                    and 0 <= last_key < len(current_level)):
+                del current_level[last_key]
+            elif last_key in current_level:
+                del current_level[last_key]
+        else:
+            if key in resource:
+                del resource[key]

--- a/src/hdx_cli/cli_interface/dictionary/commands.py
+++ b/src/hdx_cli/cli_interface/dictionary/commands.py
@@ -2,6 +2,7 @@
 import json
 import click
 
+from ..common.migration import migrate_a_dictionary
 from ...library_api.common.generic_resource import access_resource
 
 from ...library_api.utility.decorators import report_error_and_exit
@@ -133,6 +134,40 @@ def dict_file_delete(ctx: click.Context, dictionary_filename):
     print(f'Deleted {dictionary_filename}')
 
 
+@click.command(help='Migrate a dictionary.', name='migrate')
+@click.argument('dictionary_name', metavar='DICTIONARY_NAME', required=True, default=None)
+@click.option('-tp', '--target-profile', required=False, default=None)
+@click.option('-h', '--target-cluster-hostname', required=False, default=None)
+@click.option('-u', '--target-cluster-username', required=False, default=None)
+@click.option('-p', '--target-cluster-password', required=False, default=None)
+@click.option('-s', '--target-cluster-uri-scheme', required=False, default='https')
+@click.option('-P', '--target-project-name', required=True, default=None)
+@click.pass_context
+@report_error_and_exit(exctype=Exception)
+def migrate_dictionary(ctx: click.Context,
+                       dictionary_name: str,
+                       target_profile,
+                       target_cluster_hostname,
+                       target_cluster_username,
+                       target_cluster_password,
+                       target_cluster_uri_scheme,
+                       target_project_name):
+    if target_profile is None and not (target_cluster_hostname and target_cluster_username
+                                       and target_cluster_password and target_cluster_uri_scheme):
+        raise click.BadParameter('Either provide a --target-profile or all four target cluster options.')
+
+    user_profile = ctx.parent.obj['usercontext']
+    migrate_a_dictionary(user_profile,
+                         dictionary_name,
+                         target_profile,
+                         target_cluster_hostname,
+                         target_cluster_username,
+                         target_cluster_password,
+                         target_cluster_uri_scheme,
+                         target_project_name)
+    print(f'Migrated dictionary {dictionary_name}')
+
+
 dictionary.add_command(create_dict, name='create')
 dictionary.add_command(files)
 files.add_command(upload_file_dict, name='upload')
@@ -143,3 +178,4 @@ dictionary.add_command(command_list)
 dictionary.add_command(command_delete)
 dictionary.add_command(command_show)
 dictionary.add_command(command_settings)
+dictionary.add_command(migrate_dictionary)

--- a/src/hdx_cli/cli_interface/function/commands.py
+++ b/src/hdx_cli/cli_interface/function/commands.py
@@ -2,6 +2,7 @@
 import json
 import click
 
+from ..common.migration import migrate_a_function
 from ...library_api.userdata.token import AuthInfo
 from ...library_api.common import rest_operations as rest_ops
 from ...library_api.common.context import ProfileUserContext
@@ -99,8 +100,43 @@ def create(ctx: click.Context,
     print(f'Created function {function_name}')
 
 
+@click.command(help='Migrate a function.')
+@click.argument('function_name', metavar='FUNCTION_NAME', required=True, default=None)
+@click.option('-tp', '--target-profile', required=False, default=None)
+@click.option('-h', '--target-cluster-hostname', required=False, default=None)
+@click.option('-u', '--target-cluster-username', required=False, default=None)
+@click.option('-p', '--target-cluster-password', required=False, default=None)
+@click.option('-s', '--target-cluster-uri-scheme', required=False, default='https')
+@click.option('-P', '--target-project-name', required=True, default=None)
+@click.pass_context
+@report_error_and_exit(exctype=Exception)
+def migrate(ctx: click.Context,
+            function_name: str,
+            target_profile,
+            target_cluster_hostname,
+            target_cluster_username,
+            target_cluster_password,
+            target_cluster_uri_scheme,
+            target_project_name):
+    if target_profile is None and not (target_cluster_hostname and target_cluster_username
+                                       and target_cluster_password and target_cluster_uri_scheme):
+        raise click.BadParameter('Either provide a --target-profile or all four target cluster options.')
+
+    user_profile = ctx.parent.obj['usercontext']
+    migrate_a_function(user_profile,
+                       function_name,
+                       target_profile,
+                       target_cluster_hostname,
+                       target_cluster_username,
+                       target_cluster_password,
+                       target_cluster_uri_scheme,
+                       target_project_name)
+    print(f'Migrated function {function_name}')
+
+
 function.add_command(create)
 function.add_command(command_delete)
 function.add_command(command_list)
 function.add_command(command_show)
 function.add_command(command_settings)
+function.add_command(migrate)

--- a/src/hdx_cli/cli_interface/project/commands.py
+++ b/src/hdx_cli/cli_interface/project/commands.py
@@ -10,6 +10,7 @@ from ..common.rest_operations import (delete as command_delete,
                                       activity as command_activity,
                                       stats as command_stats)
 from ..common.misc_operations import settings as command_settings
+from ..common.migration import migrate_a_project
 
 
 @click.group(help="Project-related operations")
@@ -42,6 +43,37 @@ def create(ctx: click.Context,
     print(f'Created project {project_name}')
 
 
+@click.command(help='Migrate a project.')
+@click.argument('project_name', metavar='PROJECT_NAME', required=True, default=None)
+@click.option('-tp', '--target-profile', required=False, default=None)
+@click.option('-h', '--target-cluster-hostname', required=False, default=None)
+@click.option('-u', '--target-cluster-username', required=False, default=None)
+@click.option('-p', '--target-cluster-password', required=False, default=None)
+@click.option('-s', '--target-cluster-uri-scheme', required=False, default='https')
+@click.pass_context
+@report_error_and_exit(exctype=Exception)
+def migrate(ctx: click.Context,
+            project_name: str,
+            target_profile,
+            target_cluster_hostname,
+            target_cluster_username,
+            target_cluster_password,
+            target_cluster_uri_scheme):
+    if target_profile is None and not (target_cluster_hostname and target_cluster_username
+                                       and target_cluster_password and target_cluster_uri_scheme):
+        raise click.BadParameter('Either provide a --target-profile or all four target cluster options.')
+
+    user_profile = ctx.parent.obj['usercontext']
+    migrate_a_project(user_profile,
+                      project_name,
+                      target_profile,
+                      target_cluster_hostname,
+                      target_cluster_username,
+                      target_cluster_password,
+                      target_cluster_uri_scheme)
+    print(f'Migrated project {project_name}')
+
+
 project.add_command(command_list)
 project.add_command(create)
 project.add_command(command_delete)
@@ -49,3 +81,4 @@ project.add_command(command_show)
 project.add_command(command_settings)
 project.add_command(command_activity)
 project.add_command(command_stats)
+project.add_command(migrate)

--- a/src/hdx_cli/cli_interface/transform/commands.py
+++ b/src/hdx_cli/cli_interface/transform/commands.py
@@ -3,6 +3,7 @@ from typing import Optional
 import json
 import click
 
+from ..common.migration import migrate_a_transform
 from ..common.undecorated_click_commands import basic_transform
 from ...library_api.utility.decorators import report_error_and_exit
 from ...library_api.common.exceptions import CommandLineException
@@ -134,9 +135,47 @@ def map_from(ctx: click.Context,
     print(f'Created transform {transform_name}')
 
 
+@click.command(help='Migrate a table.')
+@click.argument('transform_name', metavar='TRANSFORM_NAME', required=True, default=None)
+@click.option('-tp', '--target-profile', required=False, default=None)
+@click.option('-h', '--target-cluster-hostname', required=False, default=None)
+@click.option('-u', '--target-cluster-username', required=False, default=None)
+@click.option('-p', '--target-cluster-password', required=False, default=None)
+@click.option('-s', '--target-cluster-uri-scheme', required=False, default='https')
+@click.option('-P', '--target-project-name', required=True, default=None)
+@click.option('-T', '--target-table-name', required=True, default=None)
+@click.pass_context
+@report_error_and_exit(exctype=Exception)
+def migrate(ctx: click.Context,
+            transform_name: str,
+            target_profile,
+            target_cluster_hostname,
+            target_cluster_username,
+            target_cluster_password,
+            target_cluster_uri_scheme,
+            target_project_name,
+            target_table_name):
+    if target_profile is None and not (target_cluster_hostname and target_cluster_username
+                                       and target_cluster_password and target_cluster_uri_scheme):
+        raise click.BadParameter('Either provide a --target-profile or all four target cluster options.')
+
+    user_profile = ctx.parent.obj['usercontext']
+    migrate_a_transform(user_profile,
+                        transform_name,
+                        target_profile,
+                        target_cluster_hostname,
+                        target_cluster_username,
+                        target_cluster_password,
+                        target_cluster_uri_scheme,
+                        target_project_name,
+                        target_table_name)
+    print(f'Migrated transform {transform_name}')
+
+
 transform.add_command(map_from)
 transform.add_command(create)
 transform.add_command(command_delete)
 transform.add_command(command_list)
 transform.add_command(command_show)
 transform.add_command(command_settings)
+transform.add_command(migrate)

--- a/src/hdx_cli/library_api/common/auth_utils.py
+++ b/src/hdx_cli/library_api/common/auth_utils.py
@@ -1,0 +1,106 @@
+from datetime import datetime
+import dataclasses as dc
+
+import functools as ft
+from pathlib import Path
+
+from .auth import load_profile, try_load_profile_from_cache_data, save_profile_cache
+from .context import ProfileUserContext, ProfileLoadContext, DEFAULT_TIMEOUT
+from .exceptions import TokenExpiredException, HdxCliException
+from .login import login
+from .config_constants import HDX_CONFIG_DIR
+
+
+def load_user_context(load_context, **args):
+    load_set_params = ft.partial(_load_set_config_parameters,
+                                 load_context=load_context)
+
+    user_context = _chain_calls_ignore_exc(try_load_profile_from_cache_data,
+                                           fail_if_token_expired,
+                                           load_set_params,
+                                           # Parameters to first function
+                                           load_ctx=load_context,
+                                           # _chain_calls_ignore_exc Function configuration
+                                           exctype=HdxCliException)
+    if not user_context:
+        user_context: ProfileUserContext = load_profile(load_context)
+        auth_info = login(user_context.username,
+                          user_context.hostname,
+                          password=args.get('password'),
+                          use_ssl=user_context.scheme == 'https')
+        user_context.auth = auth_info
+        user_context.org_id = auth_info.org_id
+        cache_dir_path = (Path(args.get('profile_config_file')).parent
+                          if args.get('profile_config_file') else HDX_CONFIG_DIR)
+        save_profile_cache(user_context,
+                           token=auth_info.token,
+                           expiration_time=auth_info.expires_at,
+                           token_type=auth_info.token_type,
+                           org_id=auth_info.org_id,
+                           cache_dir_path=cache_dir_path)
+        user_context.auth = auth_info
+
+    uri_scheme = args.get('uri_scheme')
+    timeout = args.get('timeout')
+    if uri_scheme and uri_scheme != 'default':
+        user_context.scheme = args.get('uri_scheme')
+    if timeout and timeout != DEFAULT_TIMEOUT:
+        user_context.timeout = args.get('timeout')
+
+    return user_context
+
+
+def _chain_calls_ignore_exc(*funcs, **kwargs):
+    """
+    Chain calls and return on_error_return on failure. Exceptions are considered failure if
+    they derived from provided kwarg 'exctype', otherwise they will escape.
+    on_error_default kwarg is what is returned in case of failure.
+
+    Function parameters to funcs[0] are provided in kwargs, and subsequent results
+    are provided as input of the first function.
+    """
+    # Setup function
+    exctype = kwargs.get('exctype', Exception)
+    on_error_return = kwargs.get('on_error_return', None)
+    try:
+        del kwargs['exctype']
+    except: # pylint:disable=bare-except
+        pass
+    try:
+        del kwargs['on_error_return']
+    except: # pylint:disable=bare-except
+        pass
+
+    # Run functions
+    try:
+        result = funcs[0](**kwargs)
+        if len(funcs) > 1:
+            for func in funcs[1:]:
+                result = func(result)
+        return result
+    except exctype:
+        return on_error_return
+
+
+def _load_set_config_parameters(user_context: ProfileUserContext,
+                               load_context: ProfileLoadContext):
+    """Given a profile to load and an old profile, it returns the user_context
+    with the config parameters projectname and tablename loaded."""
+    config_params = {'projectname':
+                     (prof := load_profile(load_context)).projectname,
+                     'tablename':
+                     prof.tablename,
+                     'scheme': prof.scheme}
+    user_ctx_dict = dc.asdict(user_context) | config_params
+    # Keep old auth since asdict will transform AuthInfo into a dictionary.
+    old_auth = user_context.auth
+    new_user_ctx = ProfileUserContext(**user_ctx_dict)
+    # And reassign when done
+    new_user_ctx.auth = old_auth
+    return new_user_ctx
+
+
+def fail_if_token_expired(user_context: ProfileUserContext):
+    if user_context.auth.expires_at <= datetime.now():
+        raise TokenExpiredException()
+    return user_context


### PR DESCRIPTION
`migration` provides a way to create the same resource into another cluster (or into the same one).

For example, migrate a project as follows:
- `hdxcli project migrate <project-name> --target-cluster-hostname <hostname> --target-cluster-username <username> --target-cluster-password <password> --target-cluster-uri-scheme <http/https>`

Or using profiles as follows:
- `hdxcli project migrate <project-name> --target-profile <profile-name>`