### PR TITLE
Added logging module

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -165,6 +165,17 @@ doc = ["myst-parser", "sphinx", "sphinx-book-theme"]
 test = ["coverage", "pytest", "pytest-cov"]
 
 [[package]]
+name = "logging"
+version = "0.4.9.6"
+description = "A logging module for Python"
+category = "main"
+optional = false
+python-versions = "*"
+files = [
+    {file = "logging-0.4.9.6.tar.gz", hash = "sha256:26f6b50773f085042d301085bd1bf5d9f3735704db9f37c1ce6d8b85c38f2417"},
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "3.0.0"
 description = "Python port of markdown-it. Markdown parsing, done right!"
@@ -626,4 +637,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4.0"
-content-hash = "4f63f5e17953b545a2555d037b41bb7fc30291dce1c97266883f4142a2c6a3fa"
+content-hash = "5ca64509b4e2bb0dca3c7f74167c3a1d1faeb9b3900c66d287e00fb79718e0ff"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ toml = "^0.10.2"
 sqlglot = "^10.5.10"
 trogon = "^0.5.0"
 pydantic = "^2.5.3"
+logging = "^0.4.9.6"
 
 [tool.poetry.dev-dependencies]
 # pyinstaller = "^5.3"

--- a/src/hdx_cli/cli_interface/common/cached_operations.py
+++ b/src/hdx_cli/cli_interface/common/cached_operations.py
@@ -6,11 +6,14 @@ from ...library_api.common.exceptions import HdxCliException, ResourceNotFoundEx
 from ...library_api.common.context import ProfileUserContext
 from ...library_api.utility.decorators import find_in_disk_cache
 from ...library_api.common.generic_resource import access_resource
+from ...library_api.common.logging import get_logger
+
+logger = get_logger()
 
 try:
     from ...library_api.common.config_constants import HDX_CONFIG_DIR
 except FileNotFoundError as e:
-    print(f"Error: {e}")
+    logger.error(f'{e}')
     sys.exit(1)
 
 

--- a/src/hdx_cli/cli_interface/common/rest_operations.py
+++ b/src/hdx_cli/cli_interface/common/rest_operations.py
@@ -2,7 +2,8 @@ from functools import partial
 from typing import Tuple
 import click
 
-from hdx_cli.library_api.common.exceptions import LogicException
+from ...library_api.common.exceptions import LogicException
+from ...library_api.common.logging import get_logger
 from ...library_api.utility.decorators import (report_error_and_exit,
                                                dynamic_confirmation_prompt)
 from .undecorated_click_commands import (basic_create,
@@ -11,6 +12,8 @@ from .undecorated_click_commands import (basic_create,
                                          basic_show,
                                          basic_activity,
                                          basic_stats)
+
+logger = get_logger()
 
 
 @click.command(help='Create resource.')
@@ -39,7 +42,7 @@ def create(ctx: click.Context,
     resource_path = ctx.parent.obj.get('resource_path')
     basic_create(user_profile, resource_path,
                  resource_name, body_from_file, body_from_file_type)
-    print(f'Created {resource_name}.')
+    logger.info(f'Created {resource_name}')
 
 
 _confirmation_prompt = partial(dynamic_confirmation_prompt,
@@ -61,9 +64,9 @@ def delete(ctx: click.Context, resource_name: str,
     resource_path = ctx.parent.obj.get('resource_path')
     profile = ctx.parent.obj.get('usercontext')
     if basic_delete(profile, resource_path, resource_name):
-        print(f'Deleted {resource_name}')
+        logger.info(f'Deleted {resource_name}')
     else:
-        print(f'Could not delete {resource_name}. Not found.')
+        logger.info(f'Could not delete {resource_name}. Not found')
 
 
 @click.command(help='List resources.', name='list')
@@ -106,9 +109,8 @@ def show(ctx: click.Context, indent: bool):
     _, resource_kind = _heuristically_get_resource_kind(resource_path)
     if not (resource_name := getattr(profile, resource_kind + 'name')):
         raise LogicException(f'No default {resource_kind} found in profile')
-    print(basic_show(profile, resource_path,
-                     resource_name,
-                     indent))
+    logger.info(basic_show(profile, resource_path,
+                           resource_name, indent))
 
 
 @click.command(help='Display the activity of a resource. If not resource_name is provided, '
@@ -123,7 +125,7 @@ def activity(ctx: click.Context, indent: bool):
     _, resource_kind = _heuristically_get_resource_kind(resource_path)
     if not (resource_name := getattr(profile, resource_kind + 'name')):
         raise LogicException(f'No default {resource_kind} found in profile')
-    print(basic_activity(profile, resource_path, resource_name, indent))
+    logger.info(basic_activity(profile, resource_path, resource_name, indent))
 
 
 @click.command(help='Display statistics for a resource. If not resource_name is provided, '
@@ -138,4 +140,4 @@ def stats(ctx: click.Context, indent: bool):
     _, resource_kind = _heuristically_get_resource_kind(resource_path)
     if not (resource_name := getattr(profile, resource_kind + 'name')):
         raise LogicException(f'No default {resource_kind} found in profile')
-    print(basic_stats(profile, resource_path, resource_name, indent))
+    logger.info(basic_stats(profile, resource_path, resource_name, indent))

--- a/src/hdx_cli/cli_interface/common/rest_operations.py
+++ b/src/hdx_cli/cli_interface/common/rest_operations.py
@@ -99,7 +99,7 @@ def _heuristically_get_resource_kind(resource_path) -> Tuple[str, str]:
 
 @click.command(help='Show resource. If not resource_name is provided, it will show the default '
                     'if there is one.')
-@click.option("-i", "--indent", is_flag=True, default=False,
+@click.option('-i', '--indent', is_flag=True, default=False,
               help='Indent the output.')
 @click.pass_context
 @report_error_and_exit(exctype=Exception)
@@ -115,7 +115,7 @@ def show(ctx: click.Context, indent: bool):
 
 @click.command(help='Display the activity of a resource. If not resource_name is provided, '
                     'it will show the default if there is one.')
-@click.option("-i", "--indent", is_flag=True, default=False,
+@click.option('-i', '--indent', is_flag=True, default=False,
               help='Indent the output.')
 @click.pass_context
 @report_error_and_exit(exctype=Exception)
@@ -130,7 +130,7 @@ def activity(ctx: click.Context, indent: bool):
 
 @click.command(help='Display statistics for a resource. If not resource_name is provided, '
                     'it will show the default if there is one.')
-@click.option("-i", "--indent", is_flag=True, default=False,
+@click.option('-i', '--indent', is_flag=True, default=False,
               help='Indent the output.')
 @click.pass_context
 @report_error_and_exit(exctype=Exception)

--- a/src/hdx_cli/cli_interface/dictionary/commands.py
+++ b/src/hdx_cli/cli_interface/dictionary/commands.py
@@ -4,14 +4,13 @@ import click
 
 from ..common.migration import migrate_a_dictionary
 from ...library_api.common.generic_resource import access_resource
-
 from ...library_api.utility.decorators import report_error_and_exit
 from ...library_api.common.exceptions import (ResourceNotFoundException,
                                               MissingSettingsException,
                                               InvalidFormatFileException)
 from ...library_api.common import rest_operations as rest_ops
 from ...library_api.common.context import ProfileUserContext
-
+from ...library_api.common.logging import get_logger
 from ..common.rest_operations import (delete as command_delete,
                                       list_ as command_list,
                                       show as command_show)
@@ -19,6 +18,8 @@ from ..common.rest_operations import (delete as command_delete,
 from ..common.misc_operations import settings as command_settings
 from ..common.undecorated_click_commands import (basic_create,
                                                  basic_create_with_body_from_string)
+
+logger = get_logger()
 
 
 @click.group(help="Dictionary-related operations")
@@ -89,7 +90,7 @@ def create_dict(ctx: click.Context,
                                        resource_path,
                                        dictionary_name,
                                        json.dumps(dictionary_body))
-    print(f'Created {dictionary_name}')
+    logger.info(f'Created {dictionary_name}')
 
 
 @click.command(help='Upload a dictionary file.')
@@ -112,8 +113,8 @@ def upload_file_dict(ctx: click.Context,
                  dictionary_filename,
                  dictionary_file_to_upload,
                  body_from_file_type)
-    print(f'Uploaded dictionary file from {dictionary_file_to_upload} '
-          f'with name {dictionary_filename}.')
+    logger.info(f'Uploaded dictionary file from {dictionary_file_to_upload} '
+                f'with name {dictionary_filename}.')
 
 
 @click.command(help='Delete dictionary file.')
@@ -131,7 +132,7 @@ def dict_file_delete(ctx: click.Context, dictionary_filename):
     headers = {'Authorization': f'{auth.token_type} {auth.token}',
                'Accept': 'application/json'}
     rest_ops.delete(resource_url, headers=headers, timeout=timeout)
-    print(f'Deleted {dictionary_filename}')
+    logger.info(f'Deleted {dictionary_filename}')
 
 
 @click.command(help='Migrate a dictionary.', name='migrate')
@@ -165,7 +166,7 @@ def migrate_dictionary(ctx: click.Context,
                          target_cluster_password,
                          target_cluster_uri_scheme,
                          target_project_name)
-    print(f'Migrated dictionary {dictionary_name}')
+    logger.info(f'Migrated dictionary {dictionary_name}')
 
 
 dictionary.add_command(create_dict, name='create')

--- a/src/hdx_cli/cli_interface/function/commands.py
+++ b/src/hdx_cli/cli_interface/function/commands.py
@@ -8,12 +8,14 @@ from ...library_api.common import rest_operations as rest_ops
 from ...library_api.common.context import ProfileUserContext
 from ...library_api.utility.decorators import report_error_and_exit
 from ...library_api.common.exceptions import LogicException
-
+from ...library_api.common.logging import get_logger
 from ..common.rest_operations import (delete as command_delete,
                                       list_ as command_list,
                                       show as command_show)
 
 from ..common.misc_operations import settings as command_settings
+
+logger = get_logger()
 
 
 @click.group(help="Function-related operations")
@@ -97,7 +99,7 @@ def create(ctx: click.Context,
         body['name'] = f'{function_name}'
         body['sql'] = inline_sql
     rest_ops.create(url, body=body, headers=headers, timeout=timeout)
-    print(f'Created function {function_name}')
+    logger.info(f'Created function {function_name}')
 
 
 @click.command(help='Migrate a function.')
@@ -131,7 +133,7 @@ def migrate(ctx: click.Context,
                        target_cluster_password,
                        target_cluster_uri_scheme,
                        target_project_name)
-    print(f'Migrated function {function_name}')
+    logger.info(f'Migrated function {function_name}')
 
 
 function.add_command(create)

--- a/src/hdx_cli/cli_interface/integration/commands.py
+++ b/src/hdx_cli/cli_interface/integration/commands.py
@@ -3,11 +3,13 @@ import click
 
 from ...library_api.common import rest_operations as rest_ops
 from ...library_api.common.context import ProfileUserContext
+from ...library_api.common.logging import get_logger
 from ...library_api.utility.decorators import report_error_and_exit
 from ..common.undecorated_click_commands import basic_create_with_body_from_string
 
-
 from ..common.undecorated_click_commands import basic_transform
+
+logger = get_logger()
 
 _REPO_USER = 'hydrolix/transforms'
 
@@ -63,7 +65,7 @@ def list_(ctx: click.Context):
         name = obj['name']
         description = obj['description']
         vendor = obj['vendor']
-        print(f'{name: <20} {description: <70} from {vendor: <40}')
+        logger.info(f'{name: <20} {description: <70} from {vendor: <40}')
 
 
 transform.add_command(list_, name='list')
@@ -102,7 +104,7 @@ def apply(ctx: click.Context,
                                        resource_path,
                                        transform_name,
                                        transform_contents)
-    print(f'Created transform {transform_name} from {integration_transform_name}.')
+    logger.info(f'Created transform {transform_name} from {integration_transform_name}')
 
 
 @click.command(help="Integration transforms.")
@@ -113,7 +115,7 @@ def show(ctx: click.Context, transform_name):
     #results = _github_list(ctx)
     #base_resource_url = 'https://raw.githubusercontent.com/hydrolix/transforms/dev'
     # 'Fastly/fastly_transform.json'
-    print(_basic_show(ctx, transform_name))
+    logger.info(_basic_show(ctx, transform_name))
 
 
 transform.add_command(apply, 'apply')

--- a/src/hdx_cli/cli_interface/job/commands.py
+++ b/src/hdx_cli/cli_interface/job/commands.py
@@ -3,10 +3,10 @@ import json
 
 import click
 
-
 from ...library_api.common.exceptions import LogicException, ResourceNotFoundException
 from ...library_api.common import rest_operations as rest_ops
 from ...library_api.common.context import ProfileUserContext
+from ...library_api.common.logging import get_logger
 from ..common.rest_operations import (delete as command_delete,
                                       list_ as command_list,
                                       show as command_show)
@@ -14,6 +14,8 @@ from ...library_api.utility.decorators import (report_error_and_exit,
                                                confirmation_prompt)
 from ..common.misc_operations import settings as command_settings
 from ..common.cached_operations import find_transforms
+
+logger = get_logger()
 
 
 @click.group(help="Job-related operations")
@@ -45,7 +47,7 @@ def purgejobs(ctx: click.Context):
     headers = {'Authorization': f'{auth.token_type} {auth.token}',
                'Accept': 'application/json'}
     rest_ops.create(purgejobs_url, headers=headers, timeout=timeout)
-    print('All jobs purged')
+    logger.info('All jobs purged')
 
 
 @click.group(help="Job-related operations")
@@ -140,7 +142,7 @@ def ingest(ctx: click.Context,
                                      'no --transform passed') from exc
         body['settings']['source']['transform'] = transformname
         rest_ops.create(url, body=body, headers=headers, timeout=timeout)
-    print(f'Started job {jobname}')
+    logger.info(f'Started job {jobname}')
 
 
 @click.command(help='Cancels a job.')
@@ -167,11 +169,11 @@ def cancel(ctx: click.Context,
             job_id = a_resource['uuid']
             break
     if not job_id:
-        print(f'Could not cancel {ctx.parent.command.name} {job_name}. Not found.')
+        logger.info(f'Could not cancel {ctx.parent.command.name} {job_name}. Not found')
     else:
         cancel_job_url = f'{list_url}{job_id}/cancel'
         rest_ops.create(cancel_job_url, headers=headers, timeout=timeout)
-        print(f'Cancelled {job_name}')
+        logger.info(f'Cancelled {job_name}')
 
 
 @click.command(help='Retries a job.')
@@ -196,11 +198,11 @@ def retry(ctx,
             job_id = a_resource['uuid']
             break
     if not job_id:
-        print(f'Could not retry {ctx.parent.command.name} {job_name}. Not found.')
+        logger.info(f'Could not retry {ctx.parent.command.name} {job_name}. Not found')
     else:
         retry_job_url = f'{list_url}{job_id}/retry'
         rest_ops.create(retry_job_url, headers=headers, timeout=timeout)
-        print(f'Retrying {job_name}')
+        logger.info(f'Retrying {job_name}')
 
 
 command_ingest = ingest

--- a/src/hdx_cli/cli_interface/migrate/rollback.py
+++ b/src/hdx_cli/cli_interface/migrate/rollback.py
@@ -5,8 +5,11 @@ from urllib.parse import urlparse
 
 
 from ..common.undecorated_click_commands import basic_delete
+from ...library_api.common.logging import get_logger
 from ...library_api.common.generic_resource import access_resource_detailed
 from ...library_api.common.context import ProfileUserContext
+
+logger = get_logger()
 
 
 class MigrateStatus(Enum):
@@ -51,7 +54,7 @@ class MigrationRollbackManager:
             split_path = urlparse(project_url).path.split('/')
             resource_path = '/'.join(split_path[:-2])
             if basic_delete(self._profile, resource_path, entry.name):
-                print(f'Rolled back project {entry.name}')
+                logger.info(f'Rolled back project {entry.name}')
         elif entry.resource_kind == ResourceKind.FUNCTION:
             _, function_url = access_resource_detailed(self._profile,
                                                     [('projects', entry.parents[0]),
@@ -59,7 +62,7 @@ class MigrationRollbackManager:
             split_path = urlparse(function_url).path.split('/')
             resource_path = '/'.join(split_path[:-2])
             if basic_delete(self._profile, resource_path, entry.name):
-                print(f'Rolled back function {entry.name}')
+                logger.info(f'Rolled back function {entry.name}')
 
         elif entry.resource_kind == ResourceKind.DICTIONARY:
             _, dict_url = access_resource_detailed(self._profile,
@@ -68,7 +71,7 @@ class MigrationRollbackManager:
             split_path = urlparse(dict_url).path.split('/')
             resource_path = '/'.join(split_path[:-2])
             if basic_delete(self._profile, resource_path, entry.name):
-                print(f'Rolled back dictionary {entry.name}')
+                logger.info(f'Rolled back dictionary {entry.name}')
         elif entry.resource_kind == ResourceKind.TABLE:
             _, table_url = access_resource_detailed(self._profile,
                                                     [('projects', entry.parents[0]),
@@ -76,7 +79,7 @@ class MigrationRollbackManager:
             split_path = urlparse(table_url).path.split('/')
             resource_path = '/'.join(split_path[:-2])
             if basic_delete(self._profile, resource_path, entry.name):
-                print(f'Rolled back table {entry.name}')
+                logger.info(f'Rolled back table {entry.name}')
         elif entry.resource_kind == ResourceKind.TRANSFORM:
             _, transform_url = access_resource_detailed(self._profile,
                                                         [('projects', entry.parents[0]),
@@ -85,7 +88,7 @@ class MigrationRollbackManager:
             split_path = urlparse(transform_url).path.split('/')
             resource_path = '/'.join(split_path[:-2])
             if basic_delete(self._profile, resource_path, entry.name):
-                print(f'Rolled back transform {entry.name}')
+                logger.info(f'Rolled back transform {entry.name}')
 
     def _rollback(self):
         current_entry = self.pop_entry()
@@ -100,14 +103,16 @@ class MigrationRollbackManager:
 
         if not traceback:
             return
-        print('Rolling back migration changes...')
+        logger.info('Rolling back migration changes...')
         done = False
         while not done:
             try:
                 self._rollback()
                 done = True
             except KeyboardInterrupt:
-                result = input('A rollback was in progress, are you sure you want to abort without rolling back? (y/n): ')
+                logger.info('A rollback was in progress, '
+                            'are you sure you want to abort without rolling back? [Y/n]: [!n]')
+                result = input('')
                 done = result.lower() == 'y'
 
 

--- a/src/hdx_cli/cli_interface/pool/commands.py
+++ b/src/hdx_cli/cli_interface/pool/commands.py
@@ -2,12 +2,15 @@ import click
 import json
 
 from ...library_api.utility.decorators import report_error_and_exit
+from ...library_api.common.logging import get_logger
 from ...library_api.common.context import ProfileUserContext
 from ..common.rest_operations import delete as command_delete
 from ..common.undecorated_click_commands import basic_settings
 from ..common.undecorated_click_commands import basic_create_with_body_from_string
 from ..common.rest_operations import (list_ as command_list,
                                       show as command_show)
+
+logger = get_logger()
 
 
 @click.group(help="Pool-related operations")
@@ -75,7 +78,7 @@ def create(ctx: click.Context,
 
     body = build_request_body(replicas, cpu, memory, storage, pool_service)
     basic_create_with_body_from_string(user_profile, resource_path, pool_name, json.dumps(body))
-    print(f'Created pool {pool_name}')
+    logger.info(f'Created pool {pool_name}')
 
 
 @click.command(help="Get, set or list settings on a resource. When invoked with "

--- a/src/hdx_cli/cli_interface/profile/commands.py
+++ b/src/hdx_cli/cli_interface/profile/commands.py
@@ -4,6 +4,9 @@ import toml
 from ...library_api.utility.decorators import report_error_and_exit
 from ...library_api.common.config_constants import PROFILE_CONFIG_FILE
 from ...library_api.common.profile import save_profile, get_profile_data_from_standard_input
+from ...library_api.common.logging import get_logger
+
+logger = get_logger()
 
 
 @click.group(help="Profile-related operations")
@@ -19,15 +22,15 @@ def profile(ctx: click.Context):
 def profile_show(ctx: click.Context,
                  profile_name):
     profilename = ctx.parent.obj['usercontext'].profilename if not profile_name else profile_name
-    print(f'Showing [{profilename}]')
-    print('-' * 100)
+    logger.info(f'Showing [{profilename}]')
+    logger.info('-' * 100)
     with open(PROFILE_CONFIG_FILE, 'r', encoding='utf-8') as config_file:
         cfg_dict = toml.load(config_file)
         for prof_name, prof_val in cfg_dict.items():
             if prof_name == profilename:
-                print(f"Profile: {prof_name}")
+                logger.info(f"Profile: {prof_name}")
                 for cfg_key, cfg_val in prof_val.items():
-                    print(f"{cfg_key}: {cfg_val}")
+                    logger.info(f"{cfg_key}: {cfg_val}")
 
 
 @click.command(help='List profiles')
@@ -37,7 +40,7 @@ def profile_list(ctx: click.Context):
     with open(PROFILE_CONFIG_FILE, 'r', encoding='utf-8') as config_file:
         cfg_dict = toml.load(config_file)
         for cfg_name in cfg_dict:
-            print(cfg_name)
+            logger.info(cfg_name)
 
 
 @click.command(help='Edit profile')
@@ -49,8 +52,8 @@ def profile_edit(ctx: click.Context,
     with open(PROFILE_CONFIG_FILE, 'r', encoding='utf-8') as config_file:
         cfg_dict = toml.load(config_file)
     profile_to_edit = cfg_dict[profile_name]
-    print(f'Editing [{profile_name}]')
-    print(f'-' * 100)
+    logger.info(f'Editing [{profile_name}]')
+    logger.info(f'-' * 100)
     username, hostname, scheme = (profile_to_edit['username'],
                                   profile_to_edit['hostname'],
                                   profile_to_edit['scheme'])
@@ -75,7 +78,7 @@ def profile_add(ctx: click.Context,
     with open(PROFILE_CONFIG_FILE, 'r', encoding='utf-8') as config_file:
         cfg_dict = toml.load(config_file)
     if cfg_dict.get(profile_name):
-        print(f"Error: profile '{profile_name}' already exists")
+        logger.info(f"Profile '{profile_name}' already exists.")
         return
 
     edit_profile_data = get_profile_data_from_standard_input()

--- a/src/hdx_cli/cli_interface/project/commands.py
+++ b/src/hdx_cli/cli_interface/project/commands.py
@@ -4,6 +4,7 @@ import click
 from ..common.undecorated_click_commands import basic_create
 from ...library_api.utility.decorators import report_error_and_exit
 from ...library_api.common.context import ProfileUserContext
+from ...library_api.common.logging import get_logger
 from ..common.rest_operations import (delete as command_delete,
                                       list_ as command_list,
                                       show as command_show,
@@ -11,6 +12,8 @@ from ..common.rest_operations import (delete as command_delete,
                                       stats as command_stats)
 from ..common.misc_operations import settings as command_settings
 from ..common.migration import migrate_a_project
+
+logger = get_logger()
 
 
 @click.group(help="Project-related operations")
@@ -40,7 +43,7 @@ def create(ctx: click.Context,
                  project_name,
                  None,
                  None)
-    print(f'Created project {project_name}')
+    logger.info(f'Created project {project_name}')
 
 
 @click.command(help='Migrate a project.')
@@ -71,7 +74,7 @@ def migrate(ctx: click.Context,
                       target_cluster_username,
                       target_cluster_password,
                       target_cluster_uri_scheme)
-    print(f'Migrated project {project_name}')
+    logger.info(f'Migrated project {project_name}')
 
 
 project.add_command(command_list)

--- a/src/hdx_cli/cli_interface/role/commands.py
+++ b/src/hdx_cli/cli_interface/role/commands.py
@@ -13,10 +13,13 @@ from ...library_api.userdata.token import AuthInfo
 from ...library_api.common import rest_operations as rest_ops
 from ...library_api.utility.decorators import report_error_and_exit
 from ...library_api.common.context import ProfileUserContext
+from ...library_api.common.logging import get_logger
 from ..common.undecorated_click_commands import basic_create_with_body_from_string, basic_show
 from ..common.rest_operations import (delete as command_delete,
                                       list_ as command_list,
                                       show as command_show)
+
+logger = get_logger()
 
 
 @click.group(help="Role-related operations")
@@ -116,9 +119,9 @@ def create(ctx: click.Context,
                                            resource_path,
                                            role_obj.name,
                                            role_obj.model_dump_json(by_alias=True, exclude_none=True))
-        print(f"Created role {role_obj.name}")
+        logger.info(f"Created role {role_obj.name}")
     else:
-        print("Role creation was cancelled")
+        logger.info("Role creation was cancelled")
 
 
 @click.command(help='Modify an existing role.')
@@ -139,8 +142,9 @@ def edit(ctx: click.Context,
         update_role_request(profile,
                             resource_path,
                             role_to_update.model_dump(by_alias=True, exclude_none=True))
+        logger.info(f"Updated role '{role_name}'")
     else:
-        print("Update was cancelled")
+        logger.info("Update was cancelled")
 
 
 @click.command(name='add-user', help='Add users to a role.')
@@ -160,7 +164,7 @@ def add(ctx: click.Context,
                             role_name,
                             users,
                             action='add')
-    print(f'Users added to {role_name} role')
+    logger.info(f'Added user(s) to {role_name} role')
 
 
 @click.command(name='remove-user', help='Remove users from a role.')
@@ -180,7 +184,7 @@ def remove(ctx: click.Context,
                             role_name,
                             users,
                             action='remove')
-    print(f'Users removed from {role_name} role')
+    logger.info(f'Removed user(s) from {role_name} role')
 
 
 @click.group(help="Permission-related operations.")
@@ -223,12 +227,12 @@ def _basic_list(profile, resource_path, scope_type=None):
         for resource in resources:
             if resource.get("scope_type") == scope_type:
                 for perm in resource.get("permissions"):
-                    print(f'{perm}')
+                    logger.info(f'{perm}')
     else:
         for resource in resources:
-            print(f'Scope type: {resource.get("scope_type")}')
+            logger.info(f'Scope type: {resource.get("scope_type")}')
             for perm in resource.get("permissions"):
-                print(f'  {perm}')
+                logger.info(f'  {perm}')
 
 
 def _validate_role(profile, roles: tuple) -> list:

--- a/src/hdx_cli/cli_interface/role/commands.py
+++ b/src/hdx_cli/cli_interface/role/commands.py
@@ -22,9 +22,9 @@ from ..common.rest_operations import (delete as command_delete,
 logger = get_logger()
 
 
-@click.group(help="Role-related operations")
-@click.option('--role', 'role_name', help='Perform operation on the passed role.',
-              metavar='ROLE_NAME', default=None)
+@click.group(help='Role-related operations')
+@click.option('--role', 'role_name', metavar='ROLE_NAME', default=None,
+              help='Perform operation on the passed role.')
 @click.pass_context
 def role(ctx: click.Context,
          role_name):
@@ -61,30 +61,16 @@ def validate_uuid(ctx, param, value):
                     'If no options are provided, the HDXCLI will prompt you with questions '
                     'to configure the new role. '
                     'Simply press Enter to start the interactive configuration process.')
-@click.option('--name', '-n', 'role_name',
-              type=str,
-              help='Name of the role.',
-              metavar='ROLE_NAME',
-              required=False,
-              default=None)
-@click.option('--scope-type', '-t', 'scope_type',
-              type=click.Choice(AVAILABLE_SCOPE_TYPE),
-              help='Type of scope for the role.',
-              metavar='SCOPE_TYPE',
-              required=False,
-              default=None)
-@click.option('--scope-id', '-i', 'scope_id',
-              type=str,
+@click.option('--name', '-n', 'role_name', metavar='ROLE_NAME', type=str, required=False, default=None,
+              help='Name of the role.')
+@click.option('--scope-type', '-t', 'scope_type', type=click.Choice(AVAILABLE_SCOPE_TYPE), metavar='SCOPE_TYPE',
+              required=False, default=None,
+              help='Type of scope for the role.')
+@click.option('--scope-id', '-i', 'scope_id', metavar='SCOPE_ID', type=str, required=False, default=None,
               help='Identifier for the scope (UUID).',
-              metavar='SCOPE_ID',
-              callback=validate_uuid,
-              required=False,
-              default=None)
-@click.option('--permission', '-p', 'permissions',
-              help='Specify permissions for the new role (can be used multiple times).',
-              required=False,
-              multiple=True,
-              default=None)
+              callback=validate_uuid)
+@click.option('--permission', '-p', 'permissions', required=False, multiple=True, default=None,
+              help='Specify permissions for the new role (can be used multiple times).')
 @click.pass_context
 @report_error_and_exit(exctype=Exception)
 def create(ctx: click.Context,
@@ -119,9 +105,9 @@ def create(ctx: click.Context,
                                            resource_path,
                                            role_obj.name,
                                            role_obj.model_dump_json(by_alias=True, exclude_none=True))
-        logger.info(f"Created role {role_obj.name}")
+        logger.info(f'Created role {role_obj.name}')
     else:
-        logger.info("Role creation was cancelled")
+        logger.info('Role creation was cancelled')
 
 
 @click.command(help='Modify an existing role.')
@@ -136,22 +122,20 @@ def edit(ctx: click.Context,
     role_obj = Role(**json_data)
     role_to_update = modify_role_data_from_standard_input(profile, resource_path, role_obj)
 
-    resource_path = f"{resource_path}{role_to_update.id}/"
-
     if role_to_update:
+        resource_path = f'{resource_path}{role_to_update.id}/'
         update_role_request(profile,
                             resource_path,
                             role_to_update.model_dump(by_alias=True, exclude_none=True))
-        logger.info(f"Updated role '{role_name}'")
+        logger.info(f'Updated role {role_name}')
     else:
-        logger.info("Update was cancelled")
+        logger.info('Update was cancelled')
 
 
 @click.command(name='add-user', help='Add users to a role.')
 @click.argument('role_name', metavar='ROLE_NAME')
-@click.option('-u', '--user', 'users',
-              help='Specify users to add to a role (can be used multiple times).',
-              multiple=True, default=None, required=True)
+@click.option('-u', '--user', 'users', multiple=True, default=None, required=True,
+              help='Specify users to add to a role (can be used multiple times).')
 @click.pass_context
 @report_error_and_exit(exctype=Exception)
 def add(ctx: click.Context,
@@ -169,9 +153,8 @@ def add(ctx: click.Context,
 
 @click.command(name='remove-user', help='Remove users from a role.')
 @click.argument('role_name', metavar='ROLE_NAME')
-@click.option('-u', '--user', 'users',
-              help='Specify users to remove from a role (can be used multiple times).',
-              multiple=True, default=None, required=True)
+@click.option('-u', '--user', 'users', multiple=True, default=None, required=True,
+              help='Specify users to remove from a role (can be used multiple times).')
 @click.pass_context
 @report_error_and_exit(exctype=Exception)
 def remove(ctx: click.Context,
@@ -187,7 +170,7 @@ def remove(ctx: click.Context,
     logger.info(f'Removed user(s) from {role_name} role')
 
 
-@click.group(help="Permission-related operations.")
+@click.group(help='Permission-related operations')
 @click.pass_context
 @report_error_and_exit(exctype=Exception)
 def permission(ctx: click.Context):
@@ -197,12 +180,9 @@ def permission(ctx: click.Context):
 
 
 @click.command(help='List permissions.', name='list')
-@click.option('--scope-type', '-t', 'scope_type',
-              type=click.Choice(AVAILABLE_SCOPE_TYPE),
-              help='Filter the permissions by a specific scope type.',
-              metavar='SCOPE_TYPE',
-              required=False,
-              default=None)
+@click.option('--scope-type', '-t', 'scope_type', type=click.Choice(AVAILABLE_SCOPE_TYPE), metavar='SCOPE_TYPE',
+              required=False, default=None,
+              help='Filter the permissions by a specific scope type.')
 @click.pass_context
 @report_error_and_exit(exctype=Exception)
 def list_(ctx: click.Context,
@@ -225,45 +205,14 @@ def _basic_list(profile, resource_path, scope_type=None):
                               timeout=timeout)
     if scope_type:
         for resource in resources:
-            if resource.get("scope_type") == scope_type:
+            if resource.get('scope_type') == scope_type:
                 for perm in resource.get("permissions"):
                     logger.info(f'{perm}')
     else:
         for resource in resources:
             logger.info(f'Scope type: {resource.get("scope_type")}')
-            for perm in resource.get("permissions"):
+            for perm in resource.get('permissions'):
                 logger.info(f'  {perm}')
-
-
-def _validate_role(profile, roles: tuple) -> list:
-    """
-    Checks if each name in the 'roles' list exists in the created Hydrolix roles.
-    """
-    hostname = profile.hostname
-    scheme = profile.scheme
-    timeout = profile.timeout
-    list_url = f'{scheme}://{hostname}/config/v1/roles/'
-    auth_info: AuthInfo = profile.auth
-    headers = {'Authorization': f'{auth_info.token_type} {auth_info.token}',
-               'Accept': 'application/json'}
-    resources = rest_ops.list(list_url,
-                              headers=headers,
-                              timeout=timeout)
-
-    roles = list(set(roles))
-    existing_roles = [item['name'] for item in resources]
-    valid_roles, invalid_roles = [], []
-    for role_name in roles:
-        if role_name not in existing_roles:
-            invalid_roles.append(role_name)
-        else:
-            valid_roles.append(role_name)
-
-    if invalid_roles:
-        raise InvalidRoleException(
-            f"Invalid role(s) {', '.join(invalid_roles)}.")
-
-    return valid_roles
 
 
 def _get_users_uuid(profile, users):
@@ -301,8 +250,8 @@ def _manage_users_from_role(profile, resource_path,
         raise ResourceNotFoundException('Cannot find some user.')
 
     # Creating body with each uuid
-    user_body_list = [{"uuid": user_uuid} for user_uuid in users_uuid]
-    body = {"users": user_body_list}
+    user_body_list = [{'uuid': user_uuid} for user_uuid in users_uuid]
+    body = {'users': user_body_list}
 
     hostname = profile.hostname
     scheme = profile.scheme

--- a/src/hdx_cli/cli_interface/set/commands.py
+++ b/src/hdx_cli/cli_interface/set/commands.py
@@ -7,6 +7,9 @@ import toml
 from ...library_api.utility.decorators import report_error_and_exit
 from ...library_api.common.exceptions import LogicException, ResourceNotFoundException
 from ...library_api.common.context import ProfileUserContext
+from ...library_api.common.logging import get_logger
+
+logger = get_logger()
 
 
 def _serialize_to_config_file(profile: ProfileUserContext,
@@ -40,7 +43,7 @@ def set(ctx, projectname, tablename, scheme=None):
     if tablename:
         profile.tablename = tablename
     _serialize_to_config_file(profile, profile.profile_config_file)
-    print(f"Profile '{profile.profilename}' set project/table")
+    logger.info(f"Profile '{profile.profilename}' set project/table")
 
 
 @click.command(help='Remove any set project/table')
@@ -51,4 +54,4 @@ def unset(ctx):
     profile.projectname = None
 
     _serialize_to_config_file(profile, profile.profile_config_file)
-    print(f"Profile '{profile.profilename}' unset project/table")
+    logger.info(f"Profile '{profile.profilename}' unset project/table")

--- a/src/hdx_cli/cli_interface/sources/common_commands.py
+++ b/src/hdx_cli/cli_interface/sources/common_commands.py
@@ -3,8 +3,11 @@ import click
 from ...library_api.utility.decorators import report_error_and_exit
 from ...library_api.common import rest_operations as rest_ops
 from ...library_api.common.exceptions import HdxCliException, LogicException
+from ...library_api.common.logging import get_logger
 
 from ..common.undecorated_click_commands import basic_create_with_body_from_string
+
+logger = get_logger()
 
 
 def any_source_impl(ctx: click.Context, source_name):
@@ -57,4 +60,4 @@ def create(ctx: click.Context,
     with open(source_filename, "r", encoding="utf-8") as file:
         basic_create_with_body_from_string(user_profile, resource_path,
                                            source_name, file.read())
-    print(f'Created source {source_name}')
+    logger.info(f'Created source {source_name}')

--- a/src/hdx_cli/cli_interface/storage/commands.py
+++ b/src/hdx_cli/cli_interface/storage/commands.py
@@ -6,10 +6,13 @@ from ..common.migration import migrate_a_storage
 from ...library_api.utility.decorators import (report_error_and_exit,
                                                dynamic_confirmation_prompt)
 from ...library_api.common.context import ProfileUserContext
+from ...library_api.common.logging import get_logger
 from ..common.undecorated_click_commands import basic_create_with_body_from_string
 from ..common.undecorated_click_commands import basic_delete, basic_settings
 from ..common.rest_operations import (list_ as command_list,
                                       show as command_show)
+
+logger = get_logger()
 
 
 @click.group(help="Storage-related operations")
@@ -39,7 +42,7 @@ def create(ctx: click.Context,
     with open(storage_filename, "r", encoding="utf-8") as file:
         basic_create_with_body_from_string(user_profile, resource_path,
                                            storage_name, file.read())
-    print(f'Created storage {storage_name}')
+    logger.info(f'Created storage {storage_name}')
 
 
 _confirmation_prompt = partial(dynamic_confirmation_prompt,
@@ -62,9 +65,9 @@ def delete(ctx: click.Context, resource_name: str,
     user_profile = ctx.parent.obj.get('usercontext')
     params = {"force_operation": True}
     if basic_delete(user_profile, resource_path, resource_name, params=params):
-        print(f'Deleted {resource_name}')
+        logger.info(f'Deleted {resource_name}')
     else:
-        print(f'Could not delete {resource_name}. Not found.')
+        logger.info(f'Could not delete {resource_name}. Not found')
 
 
 @click.command(help="Get, set or list settings on a resource. When invoked with "
@@ -118,7 +121,7 @@ def migrate(ctx: click.Context,
                       target_cluster_username,
                       target_cluster_password,
                       target_cluster_uri_scheme)
-    print(f'Migrated storage {storage_name}')
+    logger.info(f'Migrated storage {storage_name}')
 
 
 storage.add_command(command_list)

--- a/src/hdx_cli/cli_interface/stream/commands.py
+++ b/src/hdx_cli/cli_interface/stream/commands.py
@@ -5,6 +5,9 @@ from ...library_api.common import rest_operations as rest_ops
 from ...library_api.utility.decorators import report_error_and_exit
 from ..common.cached_operations import find_transforms
 from ...library_api.common.context import ProfileUserContext
+from ...library_api.common.logging import get_logger
+
+logger = get_logger()
 
 
 def _get_content_type(obj_type):
@@ -83,7 +86,7 @@ def ingest(ctx: click.Context,
                     body_type=bytes,
                     headers=headers,
                     timeout=timeout)
-    print('Created stream ingest')
+    logger.info('Created stream ingest')
 
 
 stream.add_command(ingest)

--- a/src/hdx_cli/cli_interface/table/commands.py
+++ b/src/hdx_cli/cli_interface/table/commands.py
@@ -8,6 +8,7 @@ from ...library_api.common import rest_operations as rest_ops
 from ...library_api.utility.decorators import report_error_and_exit
 from ...library_api.common.exceptions import HdxCliException, LogicException
 from ...library_api.common.context import ProfileUserContext
+from ...library_api.common.logging import get_logger
 from ...library_api.userdata.token import AuthInfo
 
 from ..common.rest_operations import (delete as command_delete,
@@ -19,6 +20,8 @@ from ..common.rest_operations import (delete as command_delete,
 from ..common.misc_operations import settings as command_settings
 from ..common.undecorated_click_commands import (basic_create,
                                                  basic_create_with_body_from_string)
+
+logger = get_logger()
 
 
 @click.group(help="Table-related operations")
@@ -120,7 +123,7 @@ def create(ctx: click.Context,
     else:
         basic_create(user_profile, resource_path,
                      table_name, None, None)
-    print(f'Created table {table_name}')
+    logger.info(f'Created table {table_name}')
 
 
 def _basic_summary_create(user_profile,
@@ -190,9 +193,9 @@ def command_truncate(ctx: click.Context,
     user_profile = ctx.parent.obj.get('usercontext')
     resource_path = ctx.parent.obj.get('resource_path')
     if not _basic_truncate(user_profile, resource_path, table_name):
-        print(f'Error truncating table {table_name}')
+        logger.info(f'Could not truncate table {table_name}')
         return
-    print(f'Truncated table {table_name}')
+    logger.info(f'Truncated table {table_name}')
 
 
 @click.command(help='Migrate a table.')
@@ -226,7 +229,7 @@ def migrate(ctx: click.Context,
                     target_cluster_password,
                     target_cluster_uri_scheme,
                     target_project_name)
-    print(f'Migrated table {table_name}')
+    logger.info(f'Migrated table {table_name}')
 
 
 table.add_command(create)

--- a/src/hdx_cli/cli_interface/transform/commands.py
+++ b/src/hdx_cli/cli_interface/transform/commands.py
@@ -8,19 +8,19 @@ from ..common.undecorated_click_commands import basic_transform
 from ...library_api.utility.decorators import report_error_and_exit
 from ...library_api.common.exceptions import CommandLineException
 from ...library_api.common.context import ProfileUserContext
+from ...library_api.common.logging import get_logger
 
 from ..common.rest_operations import (delete as command_delete,
                                       list_ as command_list,
                                       show as command_show)
-
 from ...library_api.ddl.common_algo import (ddl_to_create_table_info,
                                             ddl_datatype_to_hdx_datatype,
                                             generate_transform_dict)
-
 from ...library_api.ddl.common_intermediate_representation import DdlCreateTableInfo
-
 from ..common.misc_operations import settings as command_settings
 from ..common.undecorated_click_commands import basic_create_with_body_from_string
+
+logger = get_logger()
 
 
 @click.group(help="Transform-related operations")
@@ -63,7 +63,7 @@ def create(ctx: click.Context,
     with open(body_from_file, "r", encoding="utf-8") as file:
         basic_create_with_body_from_string(user_profile, resource_path,
                                            transform_name, file.read())
-    print(f'Created transform {transform_name}')
+    logger.info(f'Created transform {transform_name}')
 
 
 @click.command(help='Map a transform from a description language. (currently sql CREATE TABLE)')
@@ -123,7 +123,7 @@ def map_from(ctx: click.Context,
                                              transform_type=create_table_info.ingest_type)
     transform_str = json.dumps(transform_dict)
     if no_apply:
-        print(transform_str)
+        logger.info(transform_str)
         return
 
     user_profile = ctx.parent.obj['usercontext']
@@ -132,7 +132,7 @@ def map_from(ctx: click.Context,
                                        resource_path,
                                        transform_name,
                                        body_from_string=transform_str)
-    print(f'Created transform {transform_name}')
+    logger.info(f'Created transform {transform_name}')
 
 
 @click.command(help='Migrate a table.')
@@ -169,7 +169,7 @@ def migrate(ctx: click.Context,
                         target_cluster_uri_scheme,
                         target_project_name,
                         target_table_name)
-    print(f'Migrated transform {transform_name}')
+    logger.info(f'Migrated transform {transform_name}')
 
 
 transform.add_command(map_from)

--- a/src/hdx_cli/cli_interface/user/commands.py
+++ b/src/hdx_cli/cli_interface/user/commands.py
@@ -9,7 +9,10 @@ from ...library_api.common import rest_operations as rest_ops
 from ...library_api.utility.decorators import (report_error_and_exit,
                                                dynamic_confirmation_prompt)
 from ...library_api.common.context import ProfileUserContext
+from ...library_api.common.logging import get_logger
 from ..common.undecorated_click_commands import basic_delete, basic_show, basic_create_from_dict_body
+
+logger = get_logger()
 
 
 @click.group(help="User-related operations")
@@ -45,10 +48,9 @@ def show(ctx: click.Context, indent: int):
     resource_path = ctx.parent.obj.get('resource_path')
     if not (resource_name := getattr(profile, 'useremail')):
         raise LogicException('No default user found in profile.')
-    print(basic_show(profile, resource_path,
-                     resource_name,
-                     indent=indent,
-                     filter_field='email'))
+
+    logger.info(basic_show(profile, resource_path, resource_name,
+                     indent=indent, filter_field='email'))
 
 
 def _validate_role(ctx, param, roles):
@@ -103,7 +105,7 @@ def invite(ctx: click.Context,
         'roles': roles
     }
     basic_create_from_dict_body(profile, resource_path, body)
-    print(f'Invitation successfully sent to {email}')
+    logger.info(f'Invitation sent to {email}')
 
 
 _confirmation_prompt = partial(dynamic_confirmation_prompt,
@@ -125,9 +127,9 @@ def delete(ctx: click.Context, email: str,
     resource_path = ctx.parent.obj.get('resource_path')
     user_profile = ctx.parent.obj.get('usercontext')
     if basic_delete(user_profile, resource_path, email, filter_field='email'):
-        print(f'Deleted {email}')
+        logger.info(f'Deleted {email}')
     else:
-        print(f'Could not delete {email}. Not found.')
+        logger.info(f'Could not delete {email}. Not found')
 
 
 @click.command(name='assign-role', help='Assign roles to a user.')
@@ -154,7 +156,7 @@ def assign(ctx: click.Context,
         'roles': roles
     }
     basic_create_from_dict_body(profile, resource_path, body)
-    print(f'Roles added to {email}')
+    logger.info(f'Added role(s) to {email}')
 
 
 @click.command(name='remove-role', help='Remove roles from a user.')
@@ -188,7 +190,7 @@ def remove(ctx: click.Context,
         'roles': list(roles)
     }
     basic_create_from_dict_body(profile, resource_path, body)
-    print(f'Roles removed from {email}')
+    logger.info(f'Removed role(s) from {email}')
 
 
 def _basic_list(profile, resource_path):
@@ -204,8 +206,8 @@ def _basic_list(profile, resource_path):
                               timeout=timeout)
     for resource in resources:
         roles_name = resource.get("roles")
-        print(f'Email: {resource["email"]}', end=' | ')
-        print(f'Roles: {(", ".join(roles_name))}')
+        logger.info(f'Email: {resource["email"]}', end=' | ')
+        logger.info(f'Roles: {(", ".join(roles_name))}')
 
 
 user.add_command(list_)

--- a/src/hdx_cli/library_api/common/interactive_helpers.py
+++ b/src/hdx_cli/library_api/common/interactive_helpers.py
@@ -1,6 +1,10 @@
 from typing import Any, Optional, Tuple, Sequence
 from copy import deepcopy
 
+from .logging import get_logger
+
+logger = get_logger()
+
 __all__ = ['choose_interactively',
            'choose_from_elements_interactively']
 
@@ -14,7 +18,8 @@ def choose_interactively(prompt, *,
     if valid_choices and not isinstance(valid_choices, str):
         valid_choices = list(map(str, valid_choices))
     while not choice or choice not in valid_choices:
-        choice = input(prompt)
+        logger.info(f'{prompt}[!n]')
+        choice = input('')
         if choice == '' and default:
             return default
         if not valid_choices:
@@ -34,7 +39,7 @@ def choose_interactively(prompt, *,
                              ', '.join(valid_choices_failed[0:_SHOW_MAX_ITEMS // 2]) + '...' +
                              ', '.join(valid_choices_failed[(-_SHOW_MAX_ITEMS - 1) // 2:-1]) + '. ' +
                              f'({len(valid_choices_failed)} choices in total)')
-        print(f'Invalid choice {choice}. Valid values are {valid_choices_str}')
+        logger.info(f'Invalid choice {choice}. Valid values are {valid_choices_str}')
 
 
 def choose_from_elements_interactively(elements: Sequence[Any]) -> Tuple[int, str]:
@@ -42,8 +47,8 @@ def choose_from_elements_interactively(elements: Sequence[Any]) -> Tuple[int, st
     and the field name
     """
     for i, a_field in enumerate(elements, 1):
-        print(f'{i}. {a_field}')
-    print()
+        logger.info(f'{i}. {a_field}')
+    logger.info('')
     element_index = int(choose_interactively(
         'Please choose an index from the list: ',
         valid_choices=[str(x + 1) for x in range(len(elements))]))

--- a/src/hdx_cli/library_api/common/logging.py
+++ b/src/hdx_cli/library_api/common/logging.py
@@ -1,0 +1,58 @@
+import sys
+import logging
+
+# key to have logging outputs without '\n' new line.
+SPECIAL_CODE = '[!n]'
+
+
+class InfoStreamHandler(logging.StreamHandler):
+    def __init__(self, stream=None):
+        super().__init__(stream or sys.stdout)
+
+    def format(self, record):
+        return record.msg
+
+    def emit(self, record):
+        if SPECIAL_CODE in record.msg:
+            record.msg = record.msg.replace(SPECIAL_CODE, '')
+            self.terminator = ''
+        else:
+            self.terminator = '\n'
+
+        return super().emit(record)
+
+
+class DebugStreamHandler(logging.StreamHandler):
+    def __init__(self, stream=None):
+        super().__init__(stream or sys.stdout)
+
+    def format(self, record):
+        formatter = logging.Formatter('%(asctime)s :: %(levelname)s :: %(message)s')
+        return formatter.format(record)
+
+    def emit(self, record):
+        if SPECIAL_CODE in record.msg:
+            record.msg = record.msg.replace(SPECIAL_CODE, '')
+            self.terminator = ''
+        else:
+            self.terminator = '\n'
+
+        return super().emit(record)
+
+
+def set_debug_logger():
+    set_logger(logging.DEBUG, DebugStreamHandler())
+
+
+def set_info_logger():
+    set_logger(logging.INFO, InfoStreamHandler())
+
+
+def set_logger(level, handler: logging.StreamHandler):
+    logger = logging.getLogger()
+    logger.addHandler(handler)
+    logger.setLevel(level)
+
+
+def get_logger():
+    return logging.getLogger()

--- a/src/hdx_cli/library_api/common/login.py
+++ b/src/hdx_cli/library_api/common/login.py
@@ -7,6 +7,9 @@ import requests as req
 
 from ..userdata.token import AuthInfo
 from .exceptions import LoginException, HdxCliException, LogicException
+from .logging import get_logger
+
+logger = get_logger()
 
 
 def _do_login(username, hostname,
@@ -22,7 +25,7 @@ def _do_login(username, hostname,
                           headers={'Accept': 'application/json'},
                           timeout=15)
     except req.ConnectionError as exc:
-        print(exc)
+        logger.error(f'{exc}')
         raise LogicException(f"Connection error: could not stablish connection with host {hostname} (using {scheme}).") from exc
     except req.ConnectTimeout as exc:
         raise HdxCliException("Timeout exception.")
@@ -57,7 +60,7 @@ def _retry(num_retries, func,
         try:
             return func(*args, **kwargs)
         except HdxCliException as exc:
-            print(f'{exc}')
+            logger.error(f'{exc}')
             if tried == num_retries - 1:
                 raise
     assert False, "Unreachable code"

--- a/src/hdx_cli/library_api/common/profile.py
+++ b/src/hdx_cli/library_api/common/profile.py
@@ -8,9 +8,11 @@ import toml
 
 from .context import ProfileUserContext
 from .validation import is_valid_username, is_valid_hostname
+from .logging import get_logger
 
 from hdx_cli.library_api.common.validation import is_valid_username, is_valid_hostname
 
+logger = get_logger()
 
 @dataclass
 class ProfileWizardInfo:
@@ -31,27 +33,30 @@ def get_profile_data_from_standard_input(hostname: Optional[str] = None,
     try:
         default_hostname = f'(default: {hostname})' if hostname else ''
         while not good_hostname:
-            input_hostname = input(f'Please, type the host name of your cluster {default_hostname}: ')
+            logger.info(f'Please, type the host name of your cluster {default_hostname}: [!n]')
+            input_hostname = input('')
             if not input_hostname and default_hostname:
                 input_hostname = hostname
             good_hostname = is_valid_hostname(input_hostname)
             if not good_hostname:
-                print('Invalid host name. Please, try again')
+                logger.info('Invalid host name. Please, try again')
 
         assert(input_hostname)
         default_username = f'(default: {username})' if username else ''
         while not good_username:
-            input_username = input(f'Please, type the user name of your cluster {default_username}: ')
+            logger.info(f'Please, type the user name of your cluster {default_username}: [!n]')
+            input_username = input('')
             if not input_username and default_username:
                 input_username = username
             good_username = is_valid_username(input_username)
             if not good_username:
-                print('Invalid user name. Please, try again')
+                logger.info('Invalid user name. Please, try again')
 
         assert(input_username)
         default_scheme = f'(default: {http_scheme})' if http_scheme else ''
         while not good_scheme_choice:
-            http_scheme_choice = input(f'Will you be using https {default_scheme} (Y/N): ')
+            logger.info(f'Will you be using https {default_scheme} (Y/N): [!n]')
+            http_scheme_choice = input('')
             if http_scheme_choice.lower() == 'y':
                 input_http_scheme = 'https'
                 good_scheme_choice = True

--- a/src/hdx_cli/library_api/common/role_validator.py
+++ b/src/hdx_cli/library_api/common/role_validator.py
@@ -257,7 +257,7 @@ def _display_role_details(role):
     logger.info("-" * 40)
     logger.info("Review Role Details")
     logger.info("-" * 40)
-    logger.info("Role Name:", role.name)
+    logger.info(f"Role Name: {role.name}")
     for index, policy in enumerate(role.policies, start=1):
         logger.info(f"Policy {index}:")
         if policy.scope_type:
@@ -268,10 +268,10 @@ def _display_role_details(role):
 
 def _display_policies(policies):
     for index, policy in enumerate(policies, start=1):
-        logger.info(f"{index}. Policy:", end=' -> ')
+        logger.info(f"{index}. Policy: -> [!n]")
         if policy.scope_type:
-            logger.info(f"Scope Type: {policy.scope_type}", end=' | ')
-            logger.info(f"Scope ID: {policy.scope_id}", end=' | ')
+            logger.info(f"Scope Type: {policy.scope_type} | [!n]")
+            logger.info(f"Scope ID: {policy.scope_id} | [!n]")
         logger.info(f"Permissions: {', '.join(policy.permissions)}")
 
 

--- a/src/hdx_cli/library_api/common/role_validator.py
+++ b/src/hdx_cli/library_api/common/role_validator.py
@@ -3,9 +3,11 @@ import re
 import uuid
 from pydantic import BaseModel
 
-from ..userdata.token import AuthInfo
 from ..common import rest_operations as rest_ops
+from ..userdata.token import AuthInfo
+from .logging import get_logger
 
+logger = get_logger()
 
 AVAILABLE_SCOPE_TYPE = []
 
@@ -90,9 +92,11 @@ def get_role_data_from_standard_input(profile, resource_path) -> Union[Role, Non
 
     # ROLE NAME SECTION
     while not input_role_name:
-        input_role_name = input("Enter the name for the new role: ").strip()
+        # '[!n]' in the logger means: without new line
+        logger.info("Enter the name for the new role: [!n]")
+        input_role_name = input("").strip()
         if not input_role_name or not is_valid_rolename(input_role_name):
-            print('Invalid role name, please try again')
+            logger.info('Invalid role name, please try again')
             input_role_name = None
 
     policies = []
@@ -103,12 +107,14 @@ def get_role_data_from_standard_input(profile, resource_path) -> Union[Role, Non
         policy_details = get_data_for_policy(profile, resource_path)
         policies.append(policy_details)
 
-        add_another_policy = input("Do you want to add another Policy? [Y/n]: ").lower() == 'y'
+        logger.info("Do you want to add another Policy? [Y/n]: [!n]")
+        add_another_policy = input("").lower() == 'y'
 
     role_to_create = Role(name=input_role_name, policies=policies)
     _display_role_details(role_to_create)
 
-    confirm_creation = input("Confirm the creation of the new role? [Y/n]: ").lower()
+    logger.info("Confirm the creation of the new role? [Y/n]: [!n]")
+    confirm_creation = input("").lower()
     if confirm_creation != 'y':
         role_to_create = None
 
@@ -116,25 +122,29 @@ def get_role_data_from_standard_input(profile, resource_path) -> Union[Role, Non
 
 
 def modify_role_data_from_standard_input(profile, resource_path, role: Role) -> Union[Role, None]:
-    print(f"Starting role editing for: {role.name}")
-    print("-" * 40)
-    input_role_name = input("Enter the new name for the role (press enter to skip): ").strip()
+    logger.info(f"Starting role editing for: {role.name}")
+    logger.info("-" * 40)
+    logger.info("Enter the new name for the role (press enter to skip): [!n]")
+    input_role_name = input("").strip()
 
     while input_role_name and not is_valid_rolename(input_role_name):
-        input_role_name = input('Invalid role name, please try again (press enter to skip): ')
+        logger.info("Invalid role name, please try again (press enter to skip): [!n]")
+        input_role_name = input("")
 
     role.name = input_role_name if input_role_name else role.name
 
     selected_option = None
-    print("What would you want to do?")
+    logger.info("What would you want to do?")
     while not selected_option:
-        print("1. Add a new policy")
-        print("2. Modify an existing policy")
-        print("3. Delete a policy")
-        selected_option = input("Please select an option: ").strip()
+        logger.info("1. Add a new policy")
+        logger.info("2. Modify an existing policy")
+        logger.info("3. Delete a policy")
+
+        logger.info("Please select an option: [!n]")
+        selected_option = input("").strip()
 
         if selected_option not in function_mapping.keys():
-            print("Invalid option, please try again")
+            logger.info("Invalid option, please try again")
             selected_option = None
 
     func_to_call = (globals()
@@ -144,7 +154,8 @@ def modify_role_data_from_standard_input(profile, resource_path, role: Role) -> 
 
     _display_role_details(role_to_update)
 
-    confirm_creation = input("Confirm the update of the role? [Y/n]: ").lower()
+    logger.info("Confirm the update of the role? [Y/n]: [!n]")
+    confirm_creation = input("").lower()
     if confirm_creation != 'y':
         role_to_update = None
 
@@ -159,24 +170,29 @@ function_mapping = {
 
 
 def get_data_for_policy(profile, resource_path) -> Policy:
-    has_scope = input("Adding a Policy, does it have a specific scope? [Y/n]: ").lower() == 'y'
+    logger.info("Adding a Policy, does it have a specific scope? [Y/n]: [!n]")
+    has_scope = input("").lower() == 'y'
 
     scope_type = None
     scope_id = None
     # SCOPE SECTION
     if has_scope:
-        scope_type = input("Specify the type of scope for the role (e.g., project): ").lower()
+        logger.info("Specify the scope type for the role (e.g., project): [!n]")
+        scope_type = input("").lower()
 
         while not is_valid_scope_type(profile, resource_path, scope_type):
-            print(f"Invalid scope type. Please choose from the available types: "
-                  f"{', '.join(get_available_scope_type_list(profile, resource_path))}.")
-            scope_type = input(
-                "Specify the type of scope for the role: ").lower()
+            logger.info(f"Invalid scope type. Please choose from the available types: "
+                        f"{', '.join(get_available_scope_type_list(profile, resource_path))}.")
 
-        scope_id = input("Provide the 'uuid' for the specified scope: ")
+            logger.info("Specify the scope type for the role: [!n]")
+            scope_type = input("").lower()
+
+        logger.info("Provide the 'uuid' for the specified scope: [!n]")
+        scope_id = input("")
         while not is_valid_uuid(scope_id):
-            print("Invalid UUID format, please try again")
-            scope_id = input("Provide the 'uuid' for the specified scope: ")
+            logger.info("Invalid UUID format, please try again")
+            logger.info("Provide the 'uuid' for the specified scope: [!n]")
+            scope_id = input("")
 
     # PERMISSIONS SECTION
     selected_permissions = _select_permissions_from_scope(profile, resource_path, scope_type)
@@ -190,17 +206,17 @@ def _select_permissions_from_scope(profile, resource_path, scope_type) -> list:
     permission_list = get_permissions_by_scope_type(profile, resource_path, scope_type)
     last_index = None
     for index, item in enumerate(permission_list, start=1):
-        print(f"{index} - {item}")
+        logger.info(f"{index} - {item}")
         last_index = index
 
     if last_index is not None:
-        print(f"{last_index + 1} - All of them")
+        logger.info(f"{last_index + 1} - All of them")
 
     selected_permissions = []
     while len(selected_permissions) < 1:
-        selected_indices = input(
-            "Enter the numbers corresponding to the permissions "
-            "you'd want to add (comma-separated): ").split(',')
+        logger.info("Enter the numbers corresponding to the permissions "
+                    "you'd want to add (comma-separated): [!n]")
+        selected_indices = input("").split(',')
         selected_indices_list = [int(index.strip()) for index in selected_indices
                                  if index.strip().isdigit()]
 
@@ -212,51 +228,51 @@ def _select_permissions_from_scope(profile, resource_path, scope_type) -> list:
                                     0 < index <= len(permission_list)]
 
         if len(selected_permissions) < 1:
-            print("Invalid selection, please try again")
+            logger.info("Invalid selection, please try again")
 
     return selected_permissions
 
 
 def _remove_permissions_from_policy(permission_list) -> list:
     for index, item in enumerate(permission_list, start=1):
-        print(f"{index} - {item}")
+        logger.info(f"{index} - {item}")
 
     selected_permissions = []
     while len(selected_permissions) < 1:
-        selected_indices = input(
-            "Enter the numbers corresponding to the permissions "
-            "you'd want to add (comma-separated): ").split(',')
+        logger.info("Enter the numbers corresponding to the permissions "
+                    "you'd want to add (comma-separated): [!n]")
+        selected_indices = input("").split(',')
         selected_indices_list = [int(index.strip()) for index in selected_indices
                                  if index.strip().isdigit()]
 
         selected_permissions = [permission_list[index - 1] for index in selected_indices_list if
                                 0 < index <= len(permission_list)]
         if len(selected_permissions) < 1:
-            print("Invalid selection, please try again")
+            logger.info("Invalid selection, please try again")
 
     return selected_permissions
 
 
 def _display_role_details(role):
-    print("-" * 40)
-    print("Review Role Details")
-    print("-" * 40)
-    print("Role Name:", role.name)
+    logger.info("-" * 40)
+    logger.info("Review Role Details")
+    logger.info("-" * 40)
+    logger.info("Role Name:", role.name)
     for index, policy in enumerate(role.policies, start=1):
-        print(f"Policy {index}:")
+        logger.info(f"Policy {index}:")
         if policy.scope_type:
-            print(f"  Scope Type: {policy.scope_type}")
-            print(f"  Scope ID: {policy.scope_id}")
-        print(f"  Permissions: {', '.join(policy.permissions)}")
+            logger.info(f"  Scope Type: {policy.scope_type}")
+            logger.info(f"  Scope ID: {policy.scope_id}")
+        logger.info(f"  Permissions: {', '.join(policy.permissions)}")
 
 
 def _display_policies(policies):
     for index, policy in enumerate(policies, start=1):
-        print(f"{index}. Policy:", end=' -> ')
+        logger.info(f"{index}. Policy:", end=' -> ')
         if policy.scope_type:
-            print(f"Scope Type: {policy.scope_type}", end=' | ')
-            print(f"Scope ID: {policy.scope_id}", end=' | ')
-        print(f"Permissions: {', '.join(policy.permissions)}")
+            logger.info(f"Scope Type: {policy.scope_type}", end=' | ')
+            logger.info(f"Scope ID: {policy.scope_id}", end=' | ')
+        logger.info(f"Permissions: {', '.join(policy.permissions)}")
 
 
 def _get_selection(list_size: int,
@@ -269,14 +285,16 @@ def _get_selection(list_size: int,
     """
     selected_option = None
     while not selected_option:
-        selected_option = input(f"{input_text}: ").strip()
+        logger.info(f"{input_text}: [!n]")
+        selected_option = input("").strip()
+
         try:
             selected_option = int(selected_option)
             if 1 <= selected_option <= list_size:
                 return selected_option - 1
-            print("Invalid option, please enter a valid number")
+            logger.info("Invalid option, please try again")
         except ValueError:
-            print("Invalid input, please enter a valid integer")
+            logger.info("Invalid input, please enter a valid integer")
         selected_option = None
 
 
@@ -300,32 +318,39 @@ def modify_policy(profile, resource_path, role):
     selected_policy = _get_selection(len(role.policies), "Choose a policy to modify")
     policy = role.policies[selected_policy]
 
-    scope_type = input(f"Specify the scope type (currently: {policy.scope_type}, "
-                       f"press enter to skip): ")
+    logger.info(f"Specify the scope type (currently: {policy.scope_type}, "
+                f"press enter to skip): [!n]")
+    scope_type = input("")
 
     while scope_type and not is_valid_scope_type(profile, resource_path, scope_type):
-        print(f"Invalid scope type. Please choose from the available types: "
-              f"{', '.join(get_available_scope_type_list(profile, resource_path))}.")
-        scope_type = input(
-            "Specify the scope type (press enter to skip): ").lower()
+        logger.info(f"Invalid scope type. Please choose from the available types: "
+                    f"{', '.join(get_available_scope_type_list(profile, resource_path))}.")
+
+        logger.info("Specify the scope type (press enter to skip): [!n]")
+        scope_type = input("").lower()
 
     if scope_type:
-        scope_id = input("Provide the 'uuid' for the specified scope "
-                         f"(currently: {policy.scope_id}): ")
+        logger.info("Provide the 'uuid' for the specified scope "
+                    f"(currently: {policy.scope_id}): [!n]")
+        scope_id = input("")
         while not is_valid_uuid(scope_id):
-            print("Invalid UUID format, please try again")
-            scope_id = input("Provide the 'uuid' for the specified scope: ")
+            logger.info("Invalid UUID format, please try again")
+            logger.info("Provide the 'uuid' for the specified scope: [!n]")
+            scope_id = input("")
 
         policy.scope_type = scope_type
         policy.scope_id = scope_id
 
-    modify_permissions = input("Would you want to modify permissions? [Y/n]: ").lower() == 'y'
+    logger.info("Would you want to modify permissions? [Y/n]: [!n]")
+    modify_permissions = input("").lower() == 'y'
 
     if modify_permissions:
-        print("What would you want to do?")
-        print("1. Add permissions")
-        print("2. Remove permissions")
-        selected_option = input("Please select an option: ")
+        logger.info("What would you want to do?")
+        logger.info("1. Add permissions")
+        logger.info("2. Remove permissions")
+
+        logger.info("Please select an option: [!n]")
+        selected_option = input("")
 
         if selected_option == "1":
             # ADD PERMISSIONS
@@ -333,10 +358,14 @@ def modify_policy(profile, resource_path, role):
             current_policy_permissions = set(policy.permissions)
             current_policy_permissions.update(selected_permissions)
             policy.permissions = list(current_policy_permissions)
-        else:
+
+        elif selected_option == "2":
             # REMOVE PERMISSIONS
             permissions_to_remove = _remove_permissions_from_policy(policy.permissions)
             policy.permissions = [item for item in policy.permissions if item not in permissions_to_remove]
+
+        else:
+            logger.info("Invalid option, please try again")
 
     return role
 
@@ -357,4 +386,3 @@ def update_role_request(profile,
                              timeout=timeout,
                              body=resource_body,
                              params=None)
-    print(f"Role '{resource_body.get('name')}' updated successfully")

--- a/src/hdx_cli/library_api/ddl/common_algo.py
+++ b/src/hdx_cli/library_api/ddl/common_algo.py
@@ -10,6 +10,9 @@ from .common_intermediate_representation import (NoDdlMappingFoundError,
                                                  DdlCreateTableInfo,
                                                  DdlTypeToHdxTypeMappingFunc)
 from .interfaces import ComposedTypeParser, SourceToTableInfoProcessor, PostProcessingHook
+from ..common.logging import get_logger
+
+logger = get_logger()
 
 # pylint: disable=wildcard-import
 # pylint: disable=unused-wildcard-import
@@ -72,8 +75,8 @@ def _select_csv_indexes(ddl: DdlCreateTableInfo):
     while not done:
         try:
             for i, a_field in enumerate(fields_available):
-                print(f'{i + 1}. {a_field}')
-            print()
+                logger.info(f'{i + 1}. {a_field}')
+            logger.info('')
             valid_choices = {str(x) for x in range(1, len(fields_available))}
             field_index = int(choose_interactively(
                 'Please choose the field to assign an index for (Type Ctrl-C to finish): ',
@@ -88,15 +91,16 @@ def _select_csv_indexes(ddl: DdlCreateTableInfo):
             indexes_used.add(ingest_index)
         except KeyboardInterrupt:
             done = True
-            print()
+            logger.info('')
         except IndexError:
             pass
         except ValueError:
             pass
         except IngestIndexError as ingest_err:
-            print(f'Error: {ingest_err}')
-            input('Press Enter to continue')
-            print()
+            logger.error(f'Error: {ingest_err}')
+            logger.info('Press Enter to continue')
+            input('')
+            logger.info('')
     return field_indexes
 
 
@@ -112,7 +116,7 @@ def _choose_primary_key(cti: DdlCreateTableInfo):
         if p_key:
             not_done = False
         else:
-            print()
+            logger.info('')
     return p_key
 
 

--- a/src/hdx_cli/library_api/ddl/extensions/elastic.py
+++ b/src/hdx_cli/library_api/ddl/extensions/elastic.py
@@ -12,6 +12,9 @@ from ..interfaces import (ComposedTypeParser, SourceToTableInfoProcessor,
                           PostProcessingHook)
 
 from ...common.exceptions import NotSupportedException
+from ...common.logging import get_logger
+
+logger = get_logger()
 
 __all__ = ['ElasticSourceToTableInfoProcessor',
            'ElasticComposedTypeParser']
@@ -101,7 +104,7 @@ def _select_array_columns(fields):
             fields_chosen.add(field)
             fields.pop(idx)
         except KeyboardInterrupt:
-            print()
+            logger.info('')
             break
     return fields_chosen
 
@@ -122,13 +125,13 @@ class ElasticPostProcessingHook(PostProcessingHook):
                     assert isinstance(col_data_type, str)
                     col_data_type = ['array', col_data_type]
                 except ValueError:
-                    print(f'WARNING: ignored inexistent field {field} in elastic.array_fields')
+                    logger.warning(f'WARNING: ignored inexistent field {field} in elastic.array_fields')
             used_choices['array_fields'] = True
         if not used_choices.get('array_fields'):
             the_cols = set({c for c in ddl_create_table_info.columns
                             if not c.column_comes_from_object_field})
             sorted_columns = sorted(the_cols, key=lambda c: c.identifier)
-            print('Press Ctrl-C when you are done.')
+            logger.info('Press Ctrl-C when you are done.')
             chosen_columns = _select_array_columns(sorted_columns)
             for col in chosen_columns:
                 col.hdx_datatype = ['array', col.hdx_datatype]

--- a/src/hdx_cli/library_api/utility/decorators.py
+++ b/src/hdx_cli/library_api/utility/decorators.py
@@ -4,7 +4,8 @@ import pickle
 import atexit
 import sys
 
-from ..common.exceptions import HdxCliException
+from .json_util import http_error_pretty_format
+from ..common.exceptions import HdxCliException, HttpException
 from ..common.logging import get_logger
 
 logger = get_logger()
@@ -17,7 +18,11 @@ def report_error_and_exit(exctype=Exception, exit_code=-1):
             try:
                 return func(*args, **kwargs)
             except exctype as exc:
-                logger.error(f'Error: {exc}')
+                logger.debug(f'{exc}')
+                if isinstance(exc, HttpException):
+                    logger.error(f'Error: {http_error_pretty_format(exc)}')
+                else:
+                    logger.error(f'Error: {exc}')
                 sys.exit(exit_code)
         return report_wrapper
     return report_deco

--- a/src/hdx_cli/library_api/utility/decorators.py
+++ b/src/hdx_cli/library_api/utility/decorators.py
@@ -5,6 +5,9 @@ import atexit
 import sys
 
 from ..common.exceptions import HdxCliException
+from ..common.logging import get_logger
+
+logger = get_logger()
 
 
 def report_error_and_exit(exctype=Exception, exit_code=-1):
@@ -14,7 +17,7 @@ def report_error_and_exit(exctype=Exception, exit_code=-1):
             try:
                 return func(*args, **kwargs)
             except exctype as exc:
-                print(f'Error: {exc}')
+                logger.error(f'Error: {exc}')
                 sys.exit(exit_code)
         return report_wrapper
     return report_deco
@@ -25,7 +28,8 @@ def dynamic_confirmation_prompt(prompt, confirmation_message, fail_message,
                                 prompt_active=False):
     if not prompt_active:
         return
-    the_input = input(prompt)
+    logger.info(f'{prompt}[!n]')
+    the_input = input('')
     if the_input != confirmation_message:
         raise HdxCliException(fail_message)
 
@@ -43,6 +47,7 @@ def confirmation_prompt(prompt, confirmation_message,
 
 
 _CACHE_DICT = None
+
 
 def _save_cache(cache_file_path):
     global _CACHE_DICT

--- a/src/hdx_cli/library_api/utility/json_util.py
+++ b/src/hdx_cli/library_api/utility/json_util.py
@@ -1,4 +1,6 @@
+import logging
 from typing import Mapping, Any
+import json
 
 
 def get_dot_separated_key(dot_sep_key: str, mapping: Mapping[str, Any]):
@@ -8,3 +10,37 @@ def get_dot_separated_key(dot_sep_key: str, mapping: Mapping[str, Any]):
         for part in dot_sep_key_parts[1:]:
             key_ref = key_ref[part]
     return key_ref
+
+
+def http_error_pretty_format(error):
+    try:
+        status_code = error.error_code
+        error_data = json.loads(error.message.decode('utf-8'))
+    except json.JSONDecodeError as exc:
+        logging.debug(f'Failed to decode JSON: {exc}')
+        return f"{error}"
+    except AttributeError as exc:
+        logging.debug(f'Missing attribute: {exc}')
+        return f"{error}"
+
+    error_message = _find_error_messages(error_data)
+    if error_message:
+        return f"{error_message}"
+    else:
+        return f"{status_code} {error_data}"
+
+
+def _find_error_messages(data, error_messages=None):
+    if error_messages is None:
+        error_messages = []
+    if isinstance(data, dict):
+        for _, value in data.items():
+            _find_error_messages(value, error_messages)
+    elif isinstance(data, list):
+        for item in data:
+            _find_error_messages(item, error_messages)
+    elif isinstance(data, str):
+        if not data.endswith("."):
+            data += "."
+        error_messages.append(data)
+    return " ".join([msg.capitalize() for msg in error_messages])

--- a/tests/command_line_interface/test_cases/test_read_only_flows.ts
+++ b/tests/command_line_interface/test_cases/test_read_only_flows.ts
@@ -89,10 +89,10 @@ commands_under_test = ["python3 -m hdx_cli.main project stats"]
 teardown = ["python3 -m hdx_cli.main unset"]
 expected_output_expr = 'not result.startswith("Error:") and "name" in result and "total_partitions" in result and "total_storage_size" in result and "test_ci_project" in result'
 
-[[test]]
-name = "Project activities can be shown"
-commands_under_test = ["python3 -m hdx_cli.main project --project test_ci_project activity"]
-expected_output_expr = 'not result.startswith("Error:") and "created" in result and "test_ci_project" in result'
+#[[test]]
+#name = "Project activities can be shown"
+#commands_under_test = ["python3 -m hdx_cli.main project --project test_ci_project activity"]
+#expected_output_expr = 'not result.startswith("Error:") and "created" in result and "test_ci_project" in result'
 
 
 ######################################################### Table #########################################################

--- a/tests/command_line_interface/test_cases/test_read_only_flows.ts
+++ b/tests/command_line_interface/test_cases/test_read_only_flows.ts
@@ -34,7 +34,7 @@ global_setup = ["python3 -m hdx_cli.main project create test_ci_project",
                 "python3 -m hdx_cli.main job batch --project test_ci_project --table test_ci_table ingest test_ci_batch_job {HDXCLI_TESTS_DIR}/tests_data/batch-jobs/batch_job_ci_settings.json",
                 "python3 -m hdx_cli.main sources kafka --project test_ci_project --table test_ci_table create {HDXCLI_TESTS_DIR}/tests_data/sources/kafka_source_settings.json test_ci_kafka_source",
                 "python3 -m hdx_cli.main sources kinesis --project test_ci_project --table test_ci_table create {HDXCLI_TESTS_DIR}/tests_data/sources/kinesis_source_settings.json test_ci_kinesis_source",
-                #"python3 -m hdx_cli.main sources siem --project test_ci_project --table test_ci_table create {HDXCLI_TESTS_DIR}/tests_data/sources/siem_source_settings.json test_ci_siem_source",
+                "python3 -m hdx_cli.main sources siem --project test_ci_project --table test_ci_table create {HDXCLI_TESTS_DIR}/tests_data/sources/siem_source_settings.json test_ci_siem_source",
                 "python3 -m hdx_cli.main function --project test_ci_project create -s '(x,k,b)->k*x+b' test_ci_function",
                 "python3 -m hdx_cli.main storage create {HDXCLI_TESTS_DIR}/tests_data/storages/storage_ci_settings.json test_ci_storage",
                 "python3 -m hdx_cli.main unset"
@@ -89,11 +89,10 @@ commands_under_test = ["python3 -m hdx_cli.main project stats"]
 teardown = ["python3 -m hdx_cli.main unset"]
 expected_output_expr = 'not result.startswith("Error:") and "name" in result and "total_partitions" in result and "total_storage_size" in result and "test_ci_project" in result'
 
-# Error 500 v4.2.1
-#[[test]]
-#name = "Project activities can be shown"
-#commands_under_test = ["python3 -m hdx_cli.main project --project test_ci_project activity"]
-#expected_output_expr = 'not result.startswith("Error:") and "results" in result and "count" in result and "num_pages" in result and "test_ci_project" in result'
+[[test]]
+name = "Project activities can be shown"
+commands_under_test = ["python3 -m hdx_cli.main project --project test_ci_project activity"]
+expected_output_expr = 'not result.startswith("Error:") and "created" in result and "test_ci_project" in result'
 
 
 ######################################################### Table #########################################################
@@ -159,11 +158,10 @@ commands_under_test = ["python3 -m hdx_cli.main table stats"]
 teardown = ["python3 -m hdx_cli.main unset"]
 expected_output_expr = 'not result.startswith("Error:") and "name" in result and "total_partitions" in result and "total_storage_size" in result and "test_ci_table" in result'
 
-# Failing. The name of the table is not included in the output. v4.2.1
-#[[test]]
-#name = "Table activities can be shown"
-#commands_under_test = ["python3 -m hdx_cli.main table --project test_ci_project --table test_ci_table activity"]
-#expected_output_expr = 'not result.startswith("Error:") and "results" in result and "count" in result and "num_pages" in result and "test_ci_table" in result'
+[[test]]
+name = "Table activities can be shown"
+commands_under_test = ["python3 -m hdx_cli.main table --project test_ci_project --table test_ci_table activity"]
+expected_output_expr = 'not result.startswith("Error:") and "created" in result and "test_ci_table" in result'
 
 
 #################################################### Summary Table #####################################################
@@ -332,41 +330,40 @@ expected_output_expr = 'not result.startswith("Error:") and "name" in result and
 
 
 ########################################################## SIEM #########################################################
-# Failing all test cases. There is an issue in the endpoint /sources/siem. v4.2.1
+[[test]]
+name = "SIEM sources can be created"
+setup = ["python3 -m hdx_cli.main set test_ci_project test_ci_table"]
+commands_under_test = ["python3 -m hdx_cli.main sources siem create {HDXCLI_TESTS_DIR}/tests_data/sources/siem_source_settings.json test_siem_source"]
+teardown = ["python3 -m hdx_cli.main sources siem delete --disable-confirmation-prompt test_siem_source",
+			      "python3 -m hdx_cli.main unset"]
+expected_output = 'Created source test_siem_source'
+
+[[test]]
+name = "SIEM sources can be deleted"
+setup = ["python3 -m hdx_cli.main set test_ci_project test_ci_table",
+		     "python3 -m hdx_cli.main sources siem create {HDXCLI_TESTS_DIR}/tests_data/sources/siem_source_settings.json test_siem_source"]
+commands_under_test = ["python3 -m hdx_cli.main sources siem delete --disable-confirmation-prompt test_siem_source"]
+teardown = ["python3 -m hdx_cli.main unset"]
+expected_output = 'Deleted test_siem_source'
+
+[[test]]
+name = "SIEM sources can be listed"
+setup = ["python3 -m hdx_cli.main set test_ci_project test_ci_table"]
+commands_under_test = ["python3 -m hdx_cli.main sources siem list"]
+teardown = ["python3 -m hdx_cli.main unset"]
+expected_output_re = '.*?test_ci_siem_source.*'
+
+[[test]]
+name = "SIEM source settings can be shown"
+commands_under_test = ["python3 -m hdx_cli.main sources siem --project test_ci_project --table test_ci_table --source test_ci_siem_source settings"]
+expected_output_expr = 'not result.startswith("Error:") and "name" in result and "type" in result and "value" in result and "test_ci_siem_source" in result'
+
+# failing because of the pool is crashing
 #[[test]]
-#name = "SIEM sources can be created"
-#setup = ["python3 -m hdx_cli.main set test_ci_project test_ci_table"]
-#commands_under_test = ["python3 -m hdx_cli.main sources siem create {HDXCLI_TESTS_DIR}/tests_data/sources/siem_source_settings.json test_siem_source"]
-#teardown = ["python3 -m hdx_cli.main sources siem delete --disable-confirmation-prompt test_siem_source",
-#			      "python3 -m hdx_cli.main unset"]
-#expected_output = 'Created source test_siem_source'
-#
-#[[test]]
-#name = "SIEM sources can be deleted"
-#setup = ["python3 -m hdx_cli.main set test_ci_project test_ci_table",
-#		     "python3 -m hdx_cli.main sources siem create {HDXCLI_TESTS_DIR}/tests_data/sources/siem_source_settings.json test_siem_source"]
-#commands_under_test = ["python3 -m hdx_cli.main sources siem delete --disable-confirmation-prompt test_siem_source"]
-#teardown = ["python3 -m hdx_cli.main unset"]
-#expected_output = 'Deleted test_siem_source'
-#
-#[[test]]
-#name = "SIEM sources can be listed"
-#setup = ["python3 -m hdx_cli.main set test_ci_project test_ci_table"]
-#commands_under_test = ["python3 -m hdx_cli.main sources siem list"]
-#teardown = ["python3 -m hdx_cli.main unset"]
-#expected_output_re = '.*?test_ci_siem_source.*'
-#
-#[[test]]
-#name = "SIEM source settings can be shown"
-#commands_under_test = ["python3 -m hdx_cli.main sources siem --project test_ci_project --table test_ci_table --source test_ci_siem_source settings"]
-#expected_output_expr = 'not result.startswith("Error:") and "name" in result and "type" in result and "value" in result and "test_ci_siem_source" in result'
-#
-## failing because of the pool is crashing
-##[[test]]
-##name = "SIEM source name can be modified"
-##commands_under_test = ["python3 -m hdx_cli.main sources siem --project test_ci_project --table test_ci_table --source test_ci_siem_source settings name new_siem_name"]
-##teardown = ["python3 -m hdx_cli.main sources --project test_ci_project --table test_ci_table --source new_siem_name siem settings name test_ci_siem_source"]
-##expected_output = 'Updated test_ci_siem_source name'
+#name = "SIEM source name can be modified"
+#commands_under_test = ["python3 -m hdx_cli.main sources siem --project test_ci_project --table test_ci_table --source test_ci_siem_source settings name new_siem_name"]
+#teardown = ["python3 -m hdx_cli.main sources --project test_ci_project --table test_ci_table --source new_siem_name siem settings name test_ci_siem_source"]
+#expected_output = 'Updated test_ci_siem_source name'
 #
 #[[test]]
 #name = "SIEM source type can be shown"
@@ -379,7 +376,7 @@ expected_output_expr = 'not result.startswith("Error:") and "name" in result and
 #commands_under_test = ["python3 -m hdx_cli.main sources siem --source test_ci_siem_source show"]
 #teardown = ["python3 -m hdx_cli.main unset"]
 #expected_output_expr = 'not result.startswith("Error:") and "name" in result and "uuid" in result and "settings" in result and "\"subtype\": \"siem\"" in result'
-#
+
 
 ######################################################## Storage #######################################################
 [[test]]

--- a/tests/command_line_interface/test_runner_approval.py
+++ b/tests/command_line_interface/test_runner_approval.py
@@ -59,6 +59,7 @@ class ExpectedOutput(Enum):
 
 
 def _assert_test_output(result, expected_output_tpl: Tuple[ExpectedOutput, str]):
+    print(f'{result} ------------------------------------------------------')
     if expected_output_tpl[0] == ExpectedOutput.VERBATIM:
         assert result == expected_output_tpl[1]
     elif expected_output_tpl[0] == ExpectedOutput.REGEX:


### PR DESCRIPTION
This pull request adds a logging system to the CLI using the Python `logging` module. 

Previously, the CLI relied on `print` statements for output, which were replaced with `logging.info` and `logging.error` calls for improved logging and error handling.

The logging configuration is set to display INFO level messages in the console. DEBUG level messages can be enabled with the `--debug` flag after the root command `hdxcli`, as follows:
- `hdxcli --debug project list`

Additionally, this adds a parser to get nice http error messages, formatted as a string.