### PR TITLE
Refactored table command due to changes in summary tables

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ maintainers = [
 
 [tool.poetry]
 name = "hdxcli"
-version = "1.0-rc48"
+version = "1.0-rc49"
 description = "Hydrolix command line utility to do CRUD operations on projects, tables, transforms and other resources in Hydrolix clusters"
 authors = ["German Diago Gomez <german@hydrolix.io>", "Agustin Actis <agustin@hydrolix.io>"]
 license = "MIT license"

--- a/src/hdx_cli/library_api/utility/file_handling.py
+++ b/src/hdx_cli/library_api/utility/file_handling.py
@@ -1,0 +1,26 @@
+import click
+import json
+
+
+def load_json_settings_file(ctx, param, value):
+    if value is None:
+        return None
+    try:
+        with open(value, 'r') as json_file:
+            return json.load(json_file)
+    except FileNotFoundError as e:
+        raise click.BadParameter(f"File '{value}' not found.") from e
+    except json.JSONDecodeError as e:
+        raise click.BadParameter(f"Error decoding JSON from file '{value}'.") from e
+
+
+def load_plain_file(ctx, param, value):
+    if value is None:
+        return None
+    try:
+        return open(value, 'r').read()
+    except FileNotFoundError as e:
+        raise click.BadParameter(f"File '{value}' not found.") from e
+    except IOError as e:
+        raise click.BadParameter(f"Error reading from file '{value}'.") from e
+

--- a/src/hdx_cli/main.py
+++ b/src/hdx_cli/main.py
@@ -31,7 +31,7 @@ from hdx_cli.library_api.common.profile import save_profile, get_profile_data_fr
 from hdx_cli.library_api.common.auth_utils import load_user_context
 from hdx_cli.library_api.common.logging import set_debug_logger, set_info_logger, get_logger
 
-VERSION = "1.0-rc48"
+VERSION = "1.0-rc49"
 
 
 from hdx_cli.library_api.common.auth import (

--- a/tests/command_line_interface/test_cases/test_read_only_flows.ts
+++ b/tests/command_line_interface/test_cases/test_read_only_flows.ts
@@ -36,7 +36,7 @@ global_setup = ["python3 -m hdx_cli.main project create test_ci_project",
                 "python3 -m hdx_cli.main sources kinesis --project test_ci_project --table test_ci_table create {HDXCLI_TESTS_DIR}/tests_data/sources/kinesis_source_settings.json test_ci_kinesis_source",
                 "python3 -m hdx_cli.main sources siem --project test_ci_project --table test_ci_table create {HDXCLI_TESTS_DIR}/tests_data/sources/siem_source_settings.json test_ci_siem_source",
                 "python3 -m hdx_cli.main function --project test_ci_project create -s '(x,k,b)->k*x+b' test_ci_function",
-                "python3 -m hdx_cli.main storage create {HDXCLI_TESTS_DIR}/tests_data/storages/storage_ci_settings.json test_ci_storage",
+                "python3 -m hdx_cli.main storage create -f {HDXCLI_TESTS_DIR}/tests_data/storages/storage_ci_settings.json test_ci_storage",
                 "python3 -m hdx_cli.main unset"
                 ]
 
@@ -175,14 +175,14 @@ expected_output = 'Created table test_summary_table_stream'
 [[test]]
 name = "Summary (kafka) tables can be created"
 setup = ["python3 -m hdx_cli.main unset"]
-commands_under_test = ["python3 -m hdx_cli.main table --project test_ci_project create -t summary -f {HDXCLI_TESTS_DIR}/tests_data/summary/kafka/sql.txt -i kafka -o test_ci_kafka_source test_summary_table_kafka"]
+commands_under_test = ["python3 -m hdx_cli.main table --project test_ci_project create -t summary -f {HDXCLI_TESTS_DIR}/tests_data/summary/kafka/sql.txt test_summary_table_kafka"]
 teardown = ["python3 -m hdx_cli.main table --project test_ci_project delete --disable-confirmation-prompt test_summary_table_kafka"]
 expected_output = 'Created table test_summary_table_kafka'
 
 [[test]]
 name = "Summary (kinesis) tables can be created"
 setup = ["python3 -m hdx_cli.main unset"]
-commands_under_test = ["python3 -m hdx_cli.main table --project test_ci_project create -t summary -f {HDXCLI_TESTS_DIR}/tests_data/summary/kinesis/sql.txt -i kinesis -o test_ci_kinesis_source test_summary_table_kinesis"]
+commands_under_test = ["python3 -m hdx_cli.main table --project test_ci_project create -t summary -f {HDXCLI_TESTS_DIR}/tests_data/summary/kinesis/sql.txt test_summary_table_kinesis"]
 teardown = ["python3 -m hdx_cli.main table --project test_ci_project delete --disable-confirmation-prompt test_summary_table_kinesis"]
 expected_output = 'Created table test_summary_table_kinesis'
 
@@ -267,7 +267,7 @@ expected_output_expr = 'not result.startswith("Error:") and "name" in result and
 name = "Kafka source name can be modified"
 commands_under_test = ["python3 -m hdx_cli.main sources kafka --project test_ci_project --table test_ci_table --source test_ci_kafka_source settings name new_kafka_name"]
 teardown = ["python3 -m hdx_cli.main sources kafka --project test_ci_project --table test_ci_table --source new_kafka_name settings name test_ci_kafka_source"]
-expected_output = 'Updated test_ci_kafka_source name'
+expected_output = 'Updated new_kafka_name name'
 
 [[test]]
 name = "Kafka source bootstrap_servers can be shown"
@@ -381,13 +381,13 @@ expected_output_expr = 'not result.startswith("Error:") and "name" in result and
 ######################################################## Storage #######################################################
 [[test]]
 name = "Storages can be created"
-commands_under_test = ["python3 -m hdx_cli.main storage create {HDXCLI_TESTS_DIR}/tests_data/storages/storage_settings.json test_storage"]
+commands_under_test = ["python3 -m hdx_cli.main storage create -f {HDXCLI_TESTS_DIR}/tests_data/storages/storage_settings.json test_storage"]
 teardown = ["python3 -m hdx_cli.main storage delete --disable-confirmation-prompt test_storage"]
 expected_output = 'Created storage test_storage'
 
 [[test]]
 name = "Storages can be deleted"
-setup = ["python3 -m hdx_cli.main storage create {HDXCLI_TESTS_DIR}/tests_data/storages/storage_settings.json test_storage"]
+setup = ["python3 -m hdx_cli.main storage create -f {HDXCLI_TESTS_DIR}/tests_data/storages/storage_settings.json test_storage"]
 commands_under_test = ["python3 -m hdx_cli.main storage delete --disable-confirmation-prompt test_storage"]
 expected_output = 'Deleted test_storage'
 

--- a/tests/command_line_interface/tests_data/summary/stream/settings.json
+++ b/tests/command_line_interface/tests_data/summary/stream/settings.json
@@ -1,0 +1,20 @@
+{
+    "settings": {
+        "stream": {
+            "token_list": [],
+            "hot_data_max_age_minutes": 50,
+            "hot_data_max_active_partitions": 10,
+            "hot_data_max_rows_per_partition": 50000,
+            "hot_data_max_minutes_per_partition": 5,
+            "hot_data_max_open_seconds": 10,
+            "hot_data_max_idle_seconds": 5,
+            "cold_data_max_age_days": 1500,
+            "cold_data_max_active_partitions": 168,
+            "cold_data_max_rows_per_partition": 50000,
+            "cold_data_max_minutes_per_partition": 60,
+            "cold_data_max_open_seconds": 60,
+            "cold_data_max_idle_seconds": 30,
+            "message_queue_max_rows": 500
+        }
+    }
+}


### PR DESCRIPTION
When creating a summary table, it was necessary to specify the type of ingestion. This is no longer necessary, so the following options have been deprecated: `--ingestion-type` and `--source-name`.

On the other hand, an option has been added (`--settings-file)` to provide the settings for the table to be created. If not provided, the API will set the default settings for that table.

An example of how to use this new option:
`hdxcli table --project <project-name> create <table-name> --type summary --sql-query <query> --settings-file <settings-file>.json`