### PR TITLE
Added a new migrate command

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -13,6 +13,99 @@ files = [
 ]
 
 [[package]]
+name = "azure-core"
+version = "1.30.2"
+description = "Microsoft Azure Core Library for Python"
+category = "main"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "azure-core-1.30.2.tar.gz", hash = "sha256:a14dc210efcd608821aa472d9fb8e8d035d29b68993819147bc290a8ac224472"},
+    {file = "azure_core-1.30.2-py3-none-any.whl", hash = "sha256:cf019c1ca832e96274ae85abd3d9f752397194d9fea3b41487290562ac8abe4a"},
+]
+
+[package.dependencies]
+requests = ">=2.21.0"
+six = ">=1.11.0"
+typing-extensions = ">=4.6.0"
+
+[package.extras]
+aio = ["aiohttp (>=3.0)"]
+
+[[package]]
+name = "azure-storage-blob"
+version = "12.20.0"
+description = "Microsoft Azure Blob Storage Client Library for Python"
+category = "main"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "azure-storage-blob-12.20.0.tar.gz", hash = "sha256:eeb91256e41d4b5b9bad6a87fd0a8ade07dd58aa52344e2c8d2746e27a017d3b"},
+    {file = "azure_storage_blob-12.20.0-py3-none-any.whl", hash = "sha256:de6b3bf3a90e9341a6bcb96a2ebe981dffff993e9045818f6549afea827a52a9"},
+]
+
+[package.dependencies]
+azure-core = ">=1.28.0"
+cryptography = ">=2.1.4"
+isodate = ">=0.6.1"
+typing-extensions = ">=4.6.0"
+
+[package.extras]
+aio = ["azure-core[aio] (>=1.28.0)"]
+
+[[package]]
+name = "boto3"
+version = "1.34.142"
+description = "The AWS SDK for Python"
+category = "main"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "boto3-1.34.142-py3-none-any.whl", hash = "sha256:cae11cb54f79795e44248a9e53ec5c7328519019df1ba54bc01413f51c548626"},
+    {file = "boto3-1.34.142.tar.gz", hash = "sha256:72daee953cfa0631c584c9e3aef594079e1fe6a2f64c81ff791dab9a7b25c013"},
+]
+
+[package.dependencies]
+botocore = ">=1.34.142,<1.35.0"
+jmespath = ">=0.7.1,<2.0.0"
+s3transfer = ">=0.10.0,<0.11.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
+
+[[package]]
+name = "botocore"
+version = "1.34.142"
+description = "Low-level, data-driven core of boto 3."
+category = "main"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "botocore-1.34.142-py3-none-any.whl", hash = "sha256:9d8095bab0b93b9064e856730a7ffbbb4f897353d3170bec9ddccc5f4a3753bc"},
+    {file = "botocore-1.34.142.tar.gz", hash = "sha256:2eeb8e6be729c1f8ded723970ed6c6ac29cc3014d86a99e73428fa8bdca81f63"},
+]
+
+[package.dependencies]
+jmespath = ">=0.7.1,<2.0.0"
+python-dateutil = ">=2.1,<3.0.0"
+urllib3 = {version = ">=1.25.4,<2.2.0 || >2.2.0,<3", markers = "python_version >= \"3.10\""}
+
+[package.extras]
+crt = ["awscrt (==0.20.11)"]
+
+[[package]]
+name = "cachetools"
+version = "5.3.3"
+description = "Extensible memoizing collections and decorators"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "cachetools-5.3.3-py3-none-any.whl", hash = "sha256:0abad1021d3f8325b2fc1d2e9c8b9c9d57b04c3932657a72465447332c24d945"},
+    {file = "cachetools-5.3.3.tar.gz", hash = "sha256:ba29e2dfa0b8b556606f097407ed1aa62080ee108ab0dc5ec9d6a723a007d105"},
+]
+
+[[package]]
 name = "certifi"
 version = "2024.2.2"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -23,6 +116,71 @@ files = [
     {file = "certifi-2024.2.2-py3-none-any.whl", hash = "sha256:dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1"},
     {file = "certifi-2024.2.2.tar.gz", hash = "sha256:0569859f95fc761b18b45ef421b1290a0f65f147e92a1e5eb3e635f9a5e4e66f"},
 ]
+
+[[package]]
+name = "cffi"
+version = "1.16.0"
+description = "Foreign Function Interface for Python calling C code."
+category = "main"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "cffi-1.16.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6b3d6606d369fc1da4fd8c357d026317fbb9c9b75d36dc16e90e84c26854b088"},
+    {file = "cffi-1.16.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ac0f5edd2360eea2f1daa9e26a41db02dd4b0451b48f7c318e217ee092a213e9"},
+    {file = "cffi-1.16.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7e61e3e4fa664a8588aa25c883eab612a188c725755afff6289454d6362b9673"},
+    {file = "cffi-1.16.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a72e8961a86d19bdb45851d8f1f08b041ea37d2bd8d4fd19903bc3083d80c896"},
+    {file = "cffi-1.16.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b50bf3f55561dac5438f8e70bfcdfd74543fd60df5fa5f62d94e5867deca684"},
+    {file = "cffi-1.16.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7651c50c8c5ef7bdb41108b7b8c5a83013bfaa8a935590c5d74627c047a583c7"},
+    {file = "cffi-1.16.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e4108df7fe9b707191e55f33efbcb2d81928e10cea45527879a4749cbe472614"},
+    {file = "cffi-1.16.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:32c68ef735dbe5857c810328cb2481e24722a59a2003018885514d4c09af9743"},
+    {file = "cffi-1.16.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:673739cb539f8cdaa07d92d02efa93c9ccf87e345b9a0b556e3ecc666718468d"},
+    {file = "cffi-1.16.0-cp310-cp310-win32.whl", hash = "sha256:9f90389693731ff1f659e55c7d1640e2ec43ff725cc61b04b2f9c6d8d017df6a"},
+    {file = "cffi-1.16.0-cp310-cp310-win_amd64.whl", hash = "sha256:e6024675e67af929088fda399b2094574609396b1decb609c55fa58b028a32a1"},
+    {file = "cffi-1.16.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b84834d0cf97e7d27dd5b7f3aca7b6e9263c56308ab9dc8aae9784abb774d404"},
+    {file = "cffi-1.16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1b8ebc27c014c59692bb2664c7d13ce7a6e9a629be20e54e7271fa696ff2b417"},
+    {file = "cffi-1.16.0-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ee07e47c12890ef248766a6e55bd38ebfb2bb8edd4142d56db91b21ea68b7627"},
+    {file = "cffi-1.16.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8a9d3ebe49f084ad71f9269834ceccbf398253c9fac910c4fd7053ff1386936"},
+    {file = "cffi-1.16.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e70f54f1796669ef691ca07d046cd81a29cb4deb1e5f942003f401c0c4a2695d"},
+    {file = "cffi-1.16.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5bf44d66cdf9e893637896c7faa22298baebcd18d1ddb6d2626a6e39793a1d56"},
+    {file = "cffi-1.16.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b78010e7b97fef4bee1e896df8a4bbb6712b7f05b7ef630f9d1da00f6444d2e"},
+    {file = "cffi-1.16.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:c6a164aa47843fb1b01e941d385aab7215563bb8816d80ff3a363a9f8448a8dc"},
+    {file = "cffi-1.16.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e09f3ff613345df5e8c3667da1d918f9149bd623cd9070c983c013792a9a62eb"},
+    {file = "cffi-1.16.0-cp311-cp311-win32.whl", hash = "sha256:2c56b361916f390cd758a57f2e16233eb4f64bcbeee88a4881ea90fca14dc6ab"},
+    {file = "cffi-1.16.0-cp311-cp311-win_amd64.whl", hash = "sha256:db8e577c19c0fda0beb7e0d4e09e0ba74b1e4c092e0e40bfa12fe05b6f6d75ba"},
+    {file = "cffi-1.16.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:fa3a0128b152627161ce47201262d3140edb5a5c3da88d73a1b790a959126956"},
+    {file = "cffi-1.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:68e7c44931cc171c54ccb702482e9fc723192e88d25a0e133edd7aff8fcd1f6e"},
+    {file = "cffi-1.16.0-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:abd808f9c129ba2beda4cfc53bde801e5bcf9d6e0f22f095e45327c038bfe68e"},
+    {file = "cffi-1.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:88e2b3c14bdb32e440be531ade29d3c50a1a59cd4e51b1dd8b0865c54ea5d2e2"},
+    {file = "cffi-1.16.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fcc8eb6d5902bb1cf6dc4f187ee3ea80a1eba0a89aba40a5cb20a5087d961357"},
+    {file = "cffi-1.16.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b7be2d771cdba2942e13215c4e340bfd76398e9227ad10402a8767ab1865d2e6"},
+    {file = "cffi-1.16.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e715596e683d2ce000574bae5d07bd522c781a822866c20495e52520564f0969"},
+    {file = "cffi-1.16.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2d92b25dbf6cae33f65005baf472d2c245c050b1ce709cc4588cdcdd5495b520"},
+    {file = "cffi-1.16.0-cp312-cp312-win32.whl", hash = "sha256:b2ca4e77f9f47c55c194982e10f058db063937845bb2b7a86c84a6cfe0aefa8b"},
+    {file = "cffi-1.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:68678abf380b42ce21a5f2abde8efee05c114c2fdb2e9eef2efdb0257fba1235"},
+    {file = "cffi-1.16.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0c9ef6ff37e974b73c25eecc13952c55bceed9112be2d9d938ded8e856138bcc"},
+    {file = "cffi-1.16.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a09582f178759ee8128d9270cd1344154fd473bb77d94ce0aeb2a93ebf0feaf0"},
+    {file = "cffi-1.16.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e760191dd42581e023a68b758769e2da259b5d52e3103c6060ddc02c9edb8d7b"},
+    {file = "cffi-1.16.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:80876338e19c951fdfed6198e70bc88f1c9758b94578d5a7c4c91a87af3cf31c"},
+    {file = "cffi-1.16.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a6a14b17d7e17fa0d207ac08642c8820f84f25ce17a442fd15e27ea18d67c59b"},
+    {file = "cffi-1.16.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6602bc8dc6f3a9e02b6c22c4fc1e47aa50f8f8e6d3f78a5e16ac33ef5fefa324"},
+    {file = "cffi-1.16.0-cp38-cp38-win32.whl", hash = "sha256:131fd094d1065b19540c3d72594260f118b231090295d8c34e19a7bbcf2e860a"},
+    {file = "cffi-1.16.0-cp38-cp38-win_amd64.whl", hash = "sha256:31d13b0f99e0836b7ff893d37af07366ebc90b678b6664c955b54561fc36ef36"},
+    {file = "cffi-1.16.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:582215a0e9adbe0e379761260553ba11c58943e4bbe9c36430c4ca6ac74b15ed"},
+    {file = "cffi-1.16.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b29ebffcf550f9da55bec9e02ad430c992a87e5f512cd63388abb76f1036d8d2"},
+    {file = "cffi-1.16.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dc9b18bf40cc75f66f40a7379f6a9513244fe33c0e8aa72e2d56b0196a7ef872"},
+    {file = "cffi-1.16.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cb4a35b3642fc5c005a6755a5d17c6c8b6bcb6981baf81cea8bfbc8903e8ba8"},
+    {file = "cffi-1.16.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b86851a328eedc692acf81fb05444bdf1891747c25af7529e39ddafaf68a4f3f"},
+    {file = "cffi-1.16.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c0f31130ebc2d37cdd8e44605fb5fa7ad59049298b3f745c74fa74c62fbfcfc4"},
+    {file = "cffi-1.16.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f8e709127c6c77446a8c0a8c8bf3c8ee706a06cd44b1e827c3e6a2ee6b8c098"},
+    {file = "cffi-1.16.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:748dcd1e3d3d7cd5443ef03ce8685043294ad6bd7c02a38d1bd367cfd968e000"},
+    {file = "cffi-1.16.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:8895613bcc094d4a1b2dbe179d88d7fb4a15cee43c052e8885783fac397d91fe"},
+    {file = "cffi-1.16.0-cp39-cp39-win32.whl", hash = "sha256:ed86a35631f7bfbb28e108dd96773b9d5a6ce4811cf6ea468bb6a359b256b1e4"},
+    {file = "cffi-1.16.0-cp39-cp39-win_amd64.whl", hash = "sha256:3686dffb02459559c74dd3d81748269ffb0eb027c39a6fc99502de37d501faa8"},
+    {file = "cffi-1.16.0.tar.gz", hash = "sha256:bcb3ef43e58665bbda2fb198698fcae6776483e0c4a631aa5647806c25e02cc0"},
+]
+
+[package.dependencies]
+pycparser = "*"
 
 [[package]]
 name = "charset-normalizer"
@@ -152,6 +310,61 @@ files = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "42.0.8"
+description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "cryptography-42.0.8-cp37-abi3-macosx_10_12_universal2.whl", hash = "sha256:81d8a521705787afe7a18d5bfb47ea9d9cc068206270aad0b96a725022e18d2e"},
+    {file = "cryptography-42.0.8-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:961e61cefdcb06e0c6d7e3a1b22ebe8b996eb2bf50614e89384be54c48c6b63d"},
+    {file = "cryptography-42.0.8-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e3ec3672626e1b9e55afd0df6d774ff0e953452886e06e0f1eb7eb0c832e8902"},
+    {file = "cryptography-42.0.8-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e599b53fd95357d92304510fb7bda8523ed1f79ca98dce2f43c115950aa78801"},
+    {file = "cryptography-42.0.8-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5226d5d21ab681f432a9c1cf8b658c0cb02533eece706b155e5fbd8a0cdd3949"},
+    {file = "cryptography-42.0.8-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6b7c4f03ce01afd3b76cf69a5455caa9cfa3de8c8f493e0d3ab7d20611c8dae9"},
+    {file = "cryptography-42.0.8-cp37-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:2346b911eb349ab547076f47f2e035fc8ff2c02380a7cbbf8d87114fa0f1c583"},
+    {file = "cryptography-42.0.8-cp37-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:ad803773e9df0b92e0a817d22fd8a3675493f690b96130a5e24f1b8fabbea9c7"},
+    {file = "cryptography-42.0.8-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:2f66d9cd9147ee495a8374a45ca445819f8929a3efcd2e3df6428e46c3cbb10b"},
+    {file = "cryptography-42.0.8-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:d45b940883a03e19e944456a558b67a41160e367a719833c53de6911cabba2b7"},
+    {file = "cryptography-42.0.8-cp37-abi3-win32.whl", hash = "sha256:a0c5b2b0585b6af82d7e385f55a8bc568abff8923af147ee3c07bd8b42cda8b2"},
+    {file = "cryptography-42.0.8-cp37-abi3-win_amd64.whl", hash = "sha256:57080dee41209e556a9a4ce60d229244f7a66ef52750f813bfbe18959770cfba"},
+    {file = "cryptography-42.0.8-cp39-abi3-macosx_10_12_universal2.whl", hash = "sha256:dea567d1b0e8bc5764b9443858b673b734100c2871dc93163f58c46a97a83d28"},
+    {file = "cryptography-42.0.8-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c4783183f7cb757b73b2ae9aed6599b96338eb957233c58ca8f49a49cc32fd5e"},
+    {file = "cryptography-42.0.8-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a0608251135d0e03111152e41f0cc2392d1e74e35703960d4190b2e0f4ca9c70"},
+    {file = "cryptography-42.0.8-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:dc0fdf6787f37b1c6b08e6dfc892d9d068b5bdb671198c72072828b80bd5fe4c"},
+    {file = "cryptography-42.0.8-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:9c0c1716c8447ee7dbf08d6db2e5c41c688544c61074b54fc4564196f55c25a7"},
+    {file = "cryptography-42.0.8-cp39-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:fff12c88a672ab9c9c1cf7b0c80e3ad9e2ebd9d828d955c126be4fd3e5578c9e"},
+    {file = "cryptography-42.0.8-cp39-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:cafb92b2bc622cd1aa6a1dce4b93307792633f4c5fe1f46c6b97cf67073ec961"},
+    {file = "cryptography-42.0.8-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:31f721658a29331f895a5a54e7e82075554ccfb8b163a18719d342f5ffe5ecb1"},
+    {file = "cryptography-42.0.8-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b297f90c5723d04bcc8265fc2a0f86d4ea2e0f7ab4b6994459548d3a6b992a14"},
+    {file = "cryptography-42.0.8-cp39-abi3-win32.whl", hash = "sha256:2f88d197e66c65be5e42cd72e5c18afbfae3f741742070e3019ac8f4ac57262c"},
+    {file = "cryptography-42.0.8-cp39-abi3-win_amd64.whl", hash = "sha256:fa76fbb7596cc5839320000cdd5d0955313696d9511debab7ee7278fc8b5c84a"},
+    {file = "cryptography-42.0.8-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:ba4f0a211697362e89ad822e667d8d340b4d8d55fae72cdd619389fb5912eefe"},
+    {file = "cryptography-42.0.8-pp310-pypy310_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:81884c4d096c272f00aeb1f11cf62ccd39763581645b0812e99a91505fa48e0c"},
+    {file = "cryptography-42.0.8-pp310-pypy310_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:c9bb2ae11bfbab395bdd072985abde58ea9860ed84e59dbc0463a5d0159f5b71"},
+    {file = "cryptography-42.0.8-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:7016f837e15b0a1c119d27ecd89b3515f01f90a8615ed5e9427e30d9cdbfed3d"},
+    {file = "cryptography-42.0.8-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:5a94eccb2a81a309806027e1670a358b99b8fe8bfe9f8d329f27d72c094dde8c"},
+    {file = "cryptography-42.0.8-pp39-pypy39_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:dec9b018df185f08483f294cae6ccac29e7a6e0678996587363dc352dc65c842"},
+    {file = "cryptography-42.0.8-pp39-pypy39_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:343728aac38decfdeecf55ecab3264b015be68fc2816ca800db649607aeee648"},
+    {file = "cryptography-42.0.8-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:013629ae70b40af70c9a7a5db40abe5d9054e6f4380e50ce769947b73bf3caad"},
+    {file = "cryptography-42.0.8.tar.gz", hash = "sha256:8d09d05439ce7baa8e9e95b07ec5b6c886f548deb7e0f69ef25f64b3bce842f2"},
+]
+
+[package.dependencies]
+cffi = {version = ">=1.12", markers = "platform_python_implementation != \"PyPy\""}
+
+[package.extras]
+docs = ["sphinx (>=5.3.0)", "sphinx-rtd-theme (>=1.1.1)"]
+docstest = ["pyenchant (>=1.6.11)", "readme-renderer", "sphinxcontrib-spelling (>=4.0.1)"]
+nox = ["nox"]
+pep8test = ["check-sdist", "click", "mypy", "ruff"]
+sdist = ["build"]
+ssh = ["bcrypt (>=3.1.5)"]
+test = ["certifi", "pretend", "pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-xdist"]
+test-randomorder = ["pytest-randomly"]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.2.0"
 description = "Backport of PEP 654 (exception groups)"
@@ -165,6 +378,214 @@ files = [
 
 [package.extras]
 test = ["pytest (>=6)"]
+
+[[package]]
+name = "google-api-core"
+version = "2.19.1"
+description = "Google API client core library"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "google-api-core-2.19.1.tar.gz", hash = "sha256:f4695f1e3650b316a795108a76a1c416e6afb036199d1c1f1f110916df479ffd"},
+    {file = "google_api_core-2.19.1-py3-none-any.whl", hash = "sha256:f12a9b8309b5e21d92483bbd47ce2c445861ec7d269ef6784ecc0ea8c1fa6125"},
+]
+
+[package.dependencies]
+google-auth = ">=2.14.1,<3.0.dev0"
+googleapis-common-protos = ">=1.56.2,<2.0.dev0"
+proto-plus = ">=1.22.3,<2.0.0dev"
+protobuf = ">=3.19.5,<3.20.0 || >3.20.0,<3.20.1 || >3.20.1,<4.21.0 || >4.21.0,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<6.0.0.dev0"
+requests = ">=2.18.0,<3.0.0.dev0"
+
+[package.extras]
+grpc = ["grpcio (>=1.33.2,<2.0dev)", "grpcio (>=1.49.1,<2.0dev)", "grpcio-status (>=1.33.2,<2.0.dev0)", "grpcio-status (>=1.49.1,<2.0.dev0)"]
+grpcgcp = ["grpcio-gcp (>=0.2.2,<1.0.dev0)"]
+grpcio-gcp = ["grpcio-gcp (>=0.2.2,<1.0.dev0)"]
+
+[[package]]
+name = "google-auth"
+version = "2.32.0"
+description = "Google Authentication Library"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "google_auth-2.32.0-py2.py3-none-any.whl", hash = "sha256:53326ea2ebec768070a94bee4e1b9194c9646ea0c2bd72422785bd0f9abfad7b"},
+    {file = "google_auth-2.32.0.tar.gz", hash = "sha256:49315be72c55a6a37d62819e3573f6b416aca00721f7e3e31a008d928bf64022"},
+]
+
+[package.dependencies]
+cachetools = ">=2.0.0,<6.0"
+pyasn1-modules = ">=0.2.1"
+rsa = ">=3.1.4,<5"
+
+[package.extras]
+aiohttp = ["aiohttp (>=3.6.2,<4.0.0.dev0)", "requests (>=2.20.0,<3.0.0.dev0)"]
+enterprise-cert = ["cryptography (==36.0.2)", "pyopenssl (==22.0.0)"]
+pyopenssl = ["cryptography (>=38.0.3)", "pyopenssl (>=20.0.0)"]
+reauth = ["pyu2f (>=0.1.5)"]
+requests = ["requests (>=2.20.0,<3.0.0.dev0)"]
+
+[[package]]
+name = "google-cloud-core"
+version = "2.4.1"
+description = "Google Cloud API client core library"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "google-cloud-core-2.4.1.tar.gz", hash = "sha256:9b7749272a812bde58fff28868d0c5e2f585b82f37e09a1f6ed2d4d10f134073"},
+    {file = "google_cloud_core-2.4.1-py2.py3-none-any.whl", hash = "sha256:a9e6a4422b9ac5c29f79a0ede9485473338e2ce78d91f2370c01e730eab22e61"},
+]
+
+[package.dependencies]
+google-api-core = ">=1.31.6,<2.0.0 || >2.3.0,<3.0.0dev"
+google-auth = ">=1.25.0,<3.0dev"
+
+[package.extras]
+grpc = ["grpcio (>=1.38.0,<2.0dev)", "grpcio-status (>=1.38.0,<2.0.dev0)"]
+
+[[package]]
+name = "google-cloud-storage"
+version = "2.17.0"
+description = "Google Cloud Storage API client library"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "google-cloud-storage-2.17.0.tar.gz", hash = "sha256:49378abff54ef656b52dca5ef0f2eba9aa83dc2b2c72c78714b03a1a95fe9388"},
+    {file = "google_cloud_storage-2.17.0-py2.py3-none-any.whl", hash = "sha256:5b393bc766b7a3bc6f5407b9e665b2450d36282614b7945e570b3480a456d1e1"},
+]
+
+[package.dependencies]
+google-api-core = ">=2.15.0,<3.0.0dev"
+google-auth = ">=2.26.1,<3.0dev"
+google-cloud-core = ">=2.3.0,<3.0dev"
+google-crc32c = ">=1.0,<2.0dev"
+google-resumable-media = ">=2.6.0"
+requests = ">=2.18.0,<3.0.0dev"
+
+[package.extras]
+protobuf = ["protobuf (<5.0.0dev)"]
+
+[[package]]
+name = "google-crc32c"
+version = "1.5.0"
+description = "A python wrapper of the C library 'Google CRC32C'"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "google-crc32c-1.5.0.tar.gz", hash = "sha256:89284716bc6a5a415d4eaa11b1726d2d60a0cd12aadf5439828353662ede9dd7"},
+    {file = "google_crc32c-1.5.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:596d1f98fc70232fcb6590c439f43b350cb762fb5d61ce7b0e9db4539654cc13"},
+    {file = "google_crc32c-1.5.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:be82c3c8cfb15b30f36768797a640e800513793d6ae1724aaaafe5bf86f8f346"},
+    {file = "google_crc32c-1.5.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:461665ff58895f508e2866824a47bdee72497b091c730071f2b7575d5762ab65"},
+    {file = "google_crc32c-1.5.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e2096eddb4e7c7bdae4bd69ad364e55e07b8316653234a56552d9c988bd2d61b"},
+    {file = "google_crc32c-1.5.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:116a7c3c616dd14a3de8c64a965828b197e5f2d121fedd2f8c5585c547e87b02"},
+    {file = "google_crc32c-1.5.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:5829b792bf5822fd0a6f6eb34c5f81dd074f01d570ed7f36aa101d6fc7a0a6e4"},
+    {file = "google_crc32c-1.5.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:64e52e2b3970bd891309c113b54cf0e4384762c934d5ae56e283f9a0afcd953e"},
+    {file = "google_crc32c-1.5.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:02ebb8bf46c13e36998aeaad1de9b48f4caf545e91d14041270d9dca767b780c"},
+    {file = "google_crc32c-1.5.0-cp310-cp310-win32.whl", hash = "sha256:2e920d506ec85eb4ba50cd4228c2bec05642894d4c73c59b3a2fe20346bd00ee"},
+    {file = "google_crc32c-1.5.0-cp310-cp310-win_amd64.whl", hash = "sha256:07eb3c611ce363c51a933bf6bd7f8e3878a51d124acfc89452a75120bc436289"},
+    {file = "google_crc32c-1.5.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:cae0274952c079886567f3f4f685bcaf5708f0a23a5f5216fdab71f81a6c0273"},
+    {file = "google_crc32c-1.5.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1034d91442ead5a95b5aaef90dbfaca8633b0247d1e41621d1e9f9db88c36298"},
+    {file = "google_crc32c-1.5.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7c42c70cd1d362284289c6273adda4c6af8039a8ae12dc451dcd61cdabb8ab57"},
+    {file = "google_crc32c-1.5.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8485b340a6a9e76c62a7dce3c98e5f102c9219f4cfbf896a00cf48caf078d438"},
+    {file = "google_crc32c-1.5.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77e2fd3057c9d78e225fa0a2160f96b64a824de17840351b26825b0848022906"},
+    {file = "google_crc32c-1.5.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:f583edb943cf2e09c60441b910d6a20b4d9d626c75a36c8fcac01a6c96c01183"},
+    {file = "google_crc32c-1.5.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:a1fd716e7a01f8e717490fbe2e431d2905ab8aa598b9b12f8d10abebb36b04dd"},
+    {file = "google_crc32c-1.5.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:72218785ce41b9cfd2fc1d6a017dc1ff7acfc4c17d01053265c41a2c0cc39b8c"},
+    {file = "google_crc32c-1.5.0-cp311-cp311-win32.whl", hash = "sha256:66741ef4ee08ea0b2cc3c86916ab66b6aef03768525627fd6a1b34968b4e3709"},
+    {file = "google_crc32c-1.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:ba1eb1843304b1e5537e1fca632fa894d6f6deca8d6389636ee5b4797affb968"},
+    {file = "google_crc32c-1.5.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:98cb4d057f285bd80d8778ebc4fde6b4d509ac3f331758fb1528b733215443ae"},
+    {file = "google_crc32c-1.5.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fd8536e902db7e365f49e7d9029283403974ccf29b13fc7028b97e2295b33556"},
+    {file = "google_crc32c-1.5.0-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:19e0a019d2c4dcc5e598cd4a4bc7b008546b0358bd322537c74ad47a5386884f"},
+    {file = "google_crc32c-1.5.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:02c65b9817512edc6a4ae7c7e987fea799d2e0ee40c53ec573a692bee24de876"},
+    {file = "google_crc32c-1.5.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:6ac08d24c1f16bd2bf5eca8eaf8304812f44af5cfe5062006ec676e7e1d50afc"},
+    {file = "google_crc32c-1.5.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:3359fc442a743e870f4588fcf5dcbc1bf929df1fad8fb9905cd94e5edb02e84c"},
+    {file = "google_crc32c-1.5.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:1e986b206dae4476f41bcec1faa057851f3889503a70e1bdb2378d406223994a"},
+    {file = "google_crc32c-1.5.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:de06adc872bcd8c2a4e0dc51250e9e65ef2ca91be023b9d13ebd67c2ba552e1e"},
+    {file = "google_crc32c-1.5.0-cp37-cp37m-win32.whl", hash = "sha256:d3515f198eaa2f0ed49f8819d5732d70698c3fa37384146079b3799b97667a94"},
+    {file = "google_crc32c-1.5.0-cp37-cp37m-win_amd64.whl", hash = "sha256:67b741654b851abafb7bc625b6d1cdd520a379074e64b6a128e3b688c3c04740"},
+    {file = "google_crc32c-1.5.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:c02ec1c5856179f171e032a31d6f8bf84e5a75c45c33b2e20a3de353b266ebd8"},
+    {file = "google_crc32c-1.5.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:edfedb64740750e1a3b16152620220f51d58ff1b4abceb339ca92e934775c27a"},
+    {file = "google_crc32c-1.5.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84e6e8cd997930fc66d5bb4fde61e2b62ba19d62b7abd7a69920406f9ecca946"},
+    {file = "google_crc32c-1.5.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:024894d9d3cfbc5943f8f230e23950cd4906b2fe004c72e29b209420a1e6b05a"},
+    {file = "google_crc32c-1.5.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:998679bf62b7fb599d2878aa3ed06b9ce688b8974893e7223c60db155f26bd8d"},
+    {file = "google_crc32c-1.5.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:83c681c526a3439b5cf94f7420471705bbf96262f49a6fe546a6db5f687a3d4a"},
+    {file = "google_crc32c-1.5.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:4c6fdd4fccbec90cc8a01fc00773fcd5fa28db683c116ee3cb35cd5da9ef6c37"},
+    {file = "google_crc32c-1.5.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:5ae44e10a8e3407dbe138984f21e536583f2bba1be9491239f942c2464ac0894"},
+    {file = "google_crc32c-1.5.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:37933ec6e693e51a5b07505bd05de57eee12f3e8c32b07da7e73669398e6630a"},
+    {file = "google_crc32c-1.5.0-cp38-cp38-win32.whl", hash = "sha256:fe70e325aa68fa4b5edf7d1a4b6f691eb04bbccac0ace68e34820d283b5f80d4"},
+    {file = "google_crc32c-1.5.0-cp38-cp38-win_amd64.whl", hash = "sha256:74dea7751d98034887dbd821b7aae3e1d36eda111d6ca36c206c44478035709c"},
+    {file = "google_crc32c-1.5.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:c6c777a480337ac14f38564ac88ae82d4cd238bf293f0a22295b66eb89ffced7"},
+    {file = "google_crc32c-1.5.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:759ce4851a4bb15ecabae28f4d2e18983c244eddd767f560165563bf9aefbc8d"},
+    {file = "google_crc32c-1.5.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f13cae8cc389a440def0c8c52057f37359014ccbc9dc1f0827936bcd367c6100"},
+    {file = "google_crc32c-1.5.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e560628513ed34759456a416bf86b54b2476c59144a9138165c9a1575801d0d9"},
+    {file = "google_crc32c-1.5.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e1674e4307fa3024fc897ca774e9c7562c957af85df55efe2988ed9056dc4e57"},
+    {file = "google_crc32c-1.5.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:278d2ed7c16cfc075c91378c4f47924c0625f5fc84b2d50d921b18b7975bd210"},
+    {file = "google_crc32c-1.5.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:d5280312b9af0976231f9e317c20e4a61cd2f9629b7bfea6a693d1878a264ebd"},
+    {file = "google_crc32c-1.5.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:8b87e1a59c38f275c0e3676fc2ab6d59eccecfd460be267ac360cc31f7bcde96"},
+    {file = "google_crc32c-1.5.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:7c074fece789b5034b9b1404a1f8208fc2d4c6ce9decdd16e8220c5a793e6f61"},
+    {file = "google_crc32c-1.5.0-cp39-cp39-win32.whl", hash = "sha256:7f57f14606cd1dd0f0de396e1e53824c371e9544a822648cd76c034d209b559c"},
+    {file = "google_crc32c-1.5.0-cp39-cp39-win_amd64.whl", hash = "sha256:a2355cba1f4ad8b6988a4ca3feed5bff33f6af2d7f134852cf279c2aebfde541"},
+    {file = "google_crc32c-1.5.0-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:f314013e7dcd5cf45ab1945d92e713eec788166262ae8deb2cfacd53def27325"},
+    {file = "google_crc32c-1.5.0-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3b747a674c20a67343cb61d43fdd9207ce5da6a99f629c6e2541aa0e89215bcd"},
+    {file = "google_crc32c-1.5.0-pp37-pypy37_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8f24ed114432de109aa9fd317278518a5af2d31ac2ea6b952b2f7782b43da091"},
+    {file = "google_crc32c-1.5.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8667b48e7a7ef66afba2c81e1094ef526388d35b873966d8a9a447974ed9178"},
+    {file = "google_crc32c-1.5.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:1c7abdac90433b09bad6c43a43af253e688c9cfc1c86d332aed13f9a7c7f65e2"},
+    {file = "google_crc32c-1.5.0-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:6f998db4e71b645350b9ac28a2167e6632c239963ca9da411523bb439c5c514d"},
+    {file = "google_crc32c-1.5.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9c99616c853bb585301df6de07ca2cadad344fd1ada6d62bb30aec05219c45d2"},
+    {file = "google_crc32c-1.5.0-pp38-pypy38_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2ad40e31093a4af319dadf503b2467ccdc8f67c72e4bcba97f8c10cb078207b5"},
+    {file = "google_crc32c-1.5.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cd67cf24a553339d5062eff51013780a00d6f97a39ca062781d06b3a73b15462"},
+    {file = "google_crc32c-1.5.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:398af5e3ba9cf768787eef45c803ff9614cc3e22a5b2f7d7ae116df8b11e3314"},
+    {file = "google_crc32c-1.5.0-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:b1f8133c9a275df5613a451e73f36c2aea4fe13c5c8997e22cf355ebd7bd0728"},
+    {file = "google_crc32c-1.5.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9ba053c5f50430a3fcfd36f75aff9caeba0440b2d076afdb79a318d6ca245f88"},
+    {file = "google_crc32c-1.5.0-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:272d3892a1e1a2dbc39cc5cde96834c236d5327e2122d3aaa19f6614531bb6eb"},
+    {file = "google_crc32c-1.5.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:635f5d4dd18758a1fbd1049a8e8d2fee4ffed124462d837d1a02a0e009c3ab31"},
+    {file = "google_crc32c-1.5.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:c672d99a345849301784604bfeaeba4db0c7aae50b95be04dd651fd2a7310b93"},
+]
+
+[package.extras]
+testing = ["pytest"]
+
+[[package]]
+name = "google-resumable-media"
+version = "2.7.1"
+description = "Utilities for Google Media Downloads and Resumable Uploads"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "google-resumable-media-2.7.1.tar.gz", hash = "sha256:eae451a7b2e2cdbaaa0fd2eb00cc8a1ee5e95e16b55597359cbc3d27d7d90e33"},
+    {file = "google_resumable_media-2.7.1-py2.py3-none-any.whl", hash = "sha256:103ebc4ba331ab1bfdac0250f8033627a2cd7cde09e7ccff9181e31ba4315b2c"},
+]
+
+[package.dependencies]
+google-crc32c = ">=1.0,<2.0dev"
+
+[package.extras]
+aiohttp = ["aiohttp (>=3.6.2,<4.0.0dev)", "google-auth (>=1.22.0,<2.0dev)"]
+requests = ["requests (>=2.18.0,<3.0.0dev)"]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.63.2"
+description = "Common protobufs used in Google APIs"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "googleapis-common-protos-1.63.2.tar.gz", hash = "sha256:27c5abdffc4911f28101e635de1533fb4cfd2c37fbaa9174587c799fac90aa87"},
+    {file = "googleapis_common_protos-1.63.2-py2.py3-none-any.whl", hash = "sha256:27a2499c7e8aff199665b22741997e485eccc8645aa9176c7c988e6fae507945"},
+]
+
+[package.dependencies]
+protobuf = ">=3.20.2,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<6.0.0.dev0"
+
+[package.extras]
+grpc = ["grpcio (>=1.44.0,<2.0.0.dev0)"]
 
 [[package]]
 name = "idna"
@@ -188,6 +609,33 @@ python-versions = ">=3.7"
 files = [
     {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
     {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
+]
+
+[[package]]
+name = "isodate"
+version = "0.6.1"
+description = "An ISO 8601 date/time/duration parser and formatter"
+category = "main"
+optional = false
+python-versions = "*"
+files = [
+    {file = "isodate-0.6.1-py2.py3-none-any.whl", hash = "sha256:0751eece944162659049d35f4f549ed815792b38793f07cf73381c1c87cbed96"},
+    {file = "isodate-0.6.1.tar.gz", hash = "sha256:48c5881de7e8b0a0d648cb024c8062dc84e7b840ed81e864c7614fd3c127bde9"},
+]
+
+[package.dependencies]
+six = "*"
+
+[[package]]
+name = "jmespath"
+version = "1.0.1"
+description = "JSON Matching Expressions"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980"},
+    {file = "jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"},
 ]
 
 [[package]]
@@ -297,6 +745,84 @@ files = [
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
+name = "proto-plus"
+version = "1.24.0"
+description = "Beautiful, Pythonic protocol buffers."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "proto-plus-1.24.0.tar.gz", hash = "sha256:30b72a5ecafe4406b0d339db35b56c4059064e69227b8c3bda7462397f966445"},
+    {file = "proto_plus-1.24.0-py3-none-any.whl", hash = "sha256:402576830425e5f6ce4c2a6702400ac79897dab0b4343821aa5188b0fab81a12"},
+]
+
+[package.dependencies]
+protobuf = ">=3.19.0,<6.0.0dev"
+
+[package.extras]
+testing = ["google-api-core (>=1.31.5)"]
+
+[[package]]
+name = "protobuf"
+version = "5.27.2"
+description = ""
+category = "main"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "protobuf-5.27.2-cp310-abi3-win32.whl", hash = "sha256:354d84fac2b0d76062e9b3221f4abbbacdfd2a4d8af36bab0474f3a0bb30ab38"},
+    {file = "protobuf-5.27.2-cp310-abi3-win_amd64.whl", hash = "sha256:0e341109c609749d501986b835f667c6e1e24531096cff9d34ae411595e26505"},
+    {file = "protobuf-5.27.2-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:a109916aaac42bff84702fb5187f3edadbc7c97fc2c99c5ff81dd15dcce0d1e5"},
+    {file = "protobuf-5.27.2-cp38-abi3-manylinux2014_aarch64.whl", hash = "sha256:176c12b1f1c880bf7a76d9f7c75822b6a2bc3db2d28baa4d300e8ce4cde7409b"},
+    {file = "protobuf-5.27.2-cp38-abi3-manylinux2014_x86_64.whl", hash = "sha256:b848dbe1d57ed7c191dfc4ea64b8b004a3f9ece4bf4d0d80a367b76df20bf36e"},
+    {file = "protobuf-5.27.2-cp38-cp38-win32.whl", hash = "sha256:4fadd8d83e1992eed0248bc50a4a6361dc31bcccc84388c54c86e530b7f58863"},
+    {file = "protobuf-5.27.2-cp38-cp38-win_amd64.whl", hash = "sha256:610e700f02469c4a997e58e328cac6f305f649826853813177e6290416e846c6"},
+    {file = "protobuf-5.27.2-cp39-cp39-win32.whl", hash = "sha256:9e8f199bf7f97bd7ecebffcae45ebf9527603549b2b562df0fbc6d4d688f14ca"},
+    {file = "protobuf-5.27.2-cp39-cp39-win_amd64.whl", hash = "sha256:7fc3add9e6003e026da5fc9e59b131b8f22b428b991ccd53e2af8071687b4fce"},
+    {file = "protobuf-5.27.2-py3-none-any.whl", hash = "sha256:54330f07e4949d09614707c48b06d1a22f8ffb5763c159efd5c0928326a91470"},
+    {file = "protobuf-5.27.2.tar.gz", hash = "sha256:f3ecdef226b9af856075f28227ff2c90ce3a594d092c39bee5513573f25e2714"},
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.0"
+description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
+category = "main"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pyasn1-0.6.0-py2.py3-none-any.whl", hash = "sha256:cca4bb0f2df5504f02f6f8a775b6e416ff9b0b3b16f7ee80b5a3153d9b804473"},
+    {file = "pyasn1-0.6.0.tar.gz", hash = "sha256:3a35ab2c4b5ef98e17dfdec8ab074046fbda76e281c5a706ccd82328cfc8f64c"},
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.0"
+description = "A collection of ASN.1-based protocols modules"
+category = "main"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pyasn1_modules-0.4.0-py3-none-any.whl", hash = "sha256:be04f15b66c206eed667e0bb5ab27e2b1855ea54a842e5037738099e8ca4ae0b"},
+    {file = "pyasn1_modules-0.4.0.tar.gz", hash = "sha256:831dbcea1b177b28c9baddf4c6d1013c24c3accd14a1873fffaa6a2e905f17b6"},
+]
+
+[package.dependencies]
+pyasn1 = ">=0.4.6,<0.7.0"
+
+[[package]]
+name = "pycparser"
+version = "2.22"
+description = "C parser in Python"
+category = "main"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc"},
+    {file = "pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6"},
+]
 
 [[package]]
 name = "pydantic"
@@ -450,6 +976,21 @@ tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+description = "Extensions to the standard Python datetime module"
+category = "main"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+files = [
+    {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
+    {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
+]
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
 name = "requests"
 version = "2.31.0"
 description = "Python HTTP for Humans."
@@ -489,6 +1030,51 @@ pygments = ">=2.13.0,<3.0.0"
 
 [package.extras]
 jupyter = ["ipywidgets (>=7.5.1,<9)"]
+
+[[package]]
+name = "rsa"
+version = "4.9"
+description = "Pure-Python RSA implementation"
+category = "main"
+optional = false
+python-versions = ">=3.6,<4"
+files = [
+    {file = "rsa-4.9-py3-none-any.whl", hash = "sha256:90260d9058e514786967344d0ef75fa8727eed8a7d2e43ce9f4bcf1b536174f7"},
+    {file = "rsa-4.9.tar.gz", hash = "sha256:e38464a49c6c85d7f1351b0126661487a7e0a14a50f1675ec50eb34d4f20ef21"},
+]
+
+[package.dependencies]
+pyasn1 = ">=0.1.3"
+
+[[package]]
+name = "s3transfer"
+version = "0.10.2"
+description = "An Amazon S3 Transfer Manager"
+category = "main"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "s3transfer-0.10.2-py3-none-any.whl", hash = "sha256:eca1c20de70a39daee580aef4986996620f365c4e0fda6a86100231d62f1bf69"},
+    {file = "s3transfer-0.10.2.tar.gz", hash = "sha256:0711534e9356d3cc692fdde846b4a1e4b0cb6519971860796e6bc4c7aea00ef6"},
+]
+
+[package.dependencies]
+botocore = ">=1.33.2,<2.0a.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.33.2,<2.0a.0)"]
+
+[[package]]
+name = "six"
+version = "1.16.0"
+description = "Python 2 and 3 compatibility utilities"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+files = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
 
 [[package]]
 name = "sqlglot"
@@ -548,6 +1134,27 @@ files = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
+
+[[package]]
+name = "tqdm"
+version = "4.66.4"
+description = "Fast, Extensible Progress Meter"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "tqdm-4.66.4-py3-none-any.whl", hash = "sha256:b75ca56b413b030bc3f00af51fd2c1a1a5eac6a0c1cca83cbb37a5c52abce644"},
+    {file = "tqdm-4.66.4.tar.gz", hash = "sha256:e4d936c9de8727928f3be6079590e97d9abfe8d39a590be678eb5919ffc186bb"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[package.extras]
+dev = ["pytest (>=6)", "pytest-cov", "pytest-timeout", "pytest-xdist"]
+notebook = ["ipywidgets (>=6)"]
+slack = ["slack-sdk"]
+telegram = ["requests"]
 
 [[package]]
 name = "trogon"
@@ -613,4 +1220,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<4.0"
-content-hash = "4f63f5e17953b545a2555d037b41bb7fc30291dce1c97266883f4142a2c6a3fa"
+content-hash = "bba31a793fa24a65e3439a4576286ca429ba5137809353a82118f529b913631a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ maintainers = [
 
 [tool.poetry]
 name = "hdxcli"
-version = "1.0-rc51"
+version = "1.0-rc53"
 description = "Hydrolix command line utility to do CRUD operations on projects, tables, transforms and other resources in Hydrolix clusters"
 authors = ["German Diago Gomez <german@hydrolix.io>", "Agustin Actis <agustin@hydrolix.io>"]
 license = "MIT license"
@@ -33,6 +33,10 @@ sqlglot = "^10.5.10"
 trogon = "^0.5.0"
 pydantic = "^2.5.3"
 #logging = "^0.4.9.6"
+boto3 = "^1.34.142"
+google-cloud-storage = "^2.17.0"
+tqdm = "^4.66.4"
+azure-storage-blob = "^12.20.0"
 
 [tool.poetry.dev-dependencies]
 # pyinstaller = "^5.3"

--- a/src/hdx_cli/cli_interface/migrate/commands_v2.py
+++ b/src/hdx_cli/cli_interface/migrate/commands_v2.py
@@ -27,16 +27,16 @@ def validate_tablename_format(ctx, param, value):
 
 
 @click.command(name='migrate')
+@click.argument('source_table', metavar='SOURCE_TABLE', required=True, default=None,
+                callback=validate_tablename_format)
+@click.argument('target_table', metavar='TARGET_TABLE', required=True, default=None,
+                callback=validate_tablename_format)
 @click.option('--target-profile', '-tp', 'target_profile_name', required=False, default=None)
 @click.option('--target-hostname', '-h', required=False, default=None)
 @click.option('--target-username', '-u', required=False, default=None)
 @click.option('--target-password', '-p', required=False, default=None)
 @click.option('--target-uri-scheme', '-s', required=False, default=None,
               type=click.Choice(['http', 'https'], case_sensitive=False))
-@click.option('--source-table', callback=validate_tablename_format, required=True, default=None,
-              help='The source table in the format "project.table" to migrate from.')
-@click.option('--target-table', callback=validate_tablename_format, required=True, default=None,
-              help='The target table in the format "project.table" to migrate to.')
 @click.option('--allow-merge', type=bool, is_flag=True, is_eager=True, default=False,
               help='Allow migration with merge process activated in the source table. '
                    'Default is False.')
@@ -57,11 +57,10 @@ def validate_tablename_format(ctx, param, value):
               help='Number of worker threads to use for migrating partitions. Default is 10.')
 @click.pass_context
 @report_error_and_exit(exctype=Exception)
-def migrate(ctx: click.Context, target_profile_name: str, target_hostname: str,
-            target_username: str, target_password: str, target_uri_scheme: str,
-            source_table: str, target_table: str, allow_merge: bool, only: str,
-            min_timestamp: datetime, max_timestamp: datetime, recovery: bool,
-            reuse_partitions: bool, workers: int):
+def migrate(ctx: click.Context, source_table: str, target_table: str, target_profile_name: str,
+            target_hostname: str, target_username: str, target_password: str,
+            target_uri_scheme: str, allow_merge: bool, only: str, min_timestamp: datetime,
+            max_timestamp: datetime, recovery: bool, reuse_partitions: bool, workers: int):
     source_profile = ctx.parent.obj['usercontext']
 
     if (target_profile_name is None and

--- a/src/hdx_cli/cli_interface/migrate/commands_v2.py
+++ b/src/hdx_cli/cli_interface/migrate/commands_v2.py
@@ -1,0 +1,126 @@
+import copy
+from datetime import datetime
+
+import click
+
+from hdx_cli.cli_interface.common.migration import get_target_profile
+from hdx_cli.cli_interface.migrate.data import migrate_data
+from hdx_cli.cli_interface.migrate.helpers import MigrationData, get_catalog
+from hdx_cli.cli_interface.migrate.resources import get_resources, creating_resources
+from hdx_cli.cli_interface.migrate.validator import validates
+from hdx_cli.library_api.utility.decorators import report_error_and_exit
+from hdx_cli.library_api.common.logging import get_logger
+
+logger = get_logger()
+
+
+class CustomDateTime(click.Option):
+    def get_help_record(self, ctx):
+        return ', '.join(self.opts), self.help
+
+
+@report_error_and_exit(exctype=Exception)
+def validate_tablename_format(ctx, param, value):
+    if value is None or len(value.split('.')) != 2:
+        raise click.BadParameter(f"'{value}' is not in the 'project_name.table_name' format.")
+    return value
+
+
+@click.command(name='migrate')
+@click.option('--target-profile', '-tp', 'target_profile_name', required=False, default=None)
+@click.option('--target-hostname', '-h', required=False, default=None)
+@click.option('--target-username', '-u', required=False, default=None)
+@click.option('--target-password', '-p', required=False, default=None)
+@click.option('--target-uri-scheme', '-s', required=False, default=None,
+              type=click.Choice(['http', 'https'], case_sensitive=False))
+@click.option('--source-table', callback=validate_tablename_format, required=True, default=None,
+              help='The source table in the format "project.table" to migrate from.')
+@click.option('--target-table', callback=validate_tablename_format, required=True, default=None,
+              help='The target table in the format "project.table" to migrate to.')
+@click.option('--allow-merge', type=bool, is_flag=True, is_eager=True, default=False,
+              help='Allow migration with merge process activated in the source table. '
+                   'Default is False.')
+@click.option('--only', cls=CustomDateTime, type=click.Choice(['resources', 'data']),
+              help='The migration type: "resources" or "data".', required=False)
+@click.option('--min-timestamp', cls=CustomDateTime, required=False,
+              type=click.DateTime(formats=['%Y-%m-%d %H:%M:%S']), default=None,
+              help='Minimum timestamp for filtering partitions in YYYY-MM-DD HH:MM:SS format.')
+@click.option('--max-timestamp', cls=CustomDateTime, required=False,
+              type=click.DateTime(formats=['%Y-%m-%d %H:%M:%S']), default=None,
+              help='Maximum timestamp for filtering partitions in YYYY-MM-DD HH:MM:SS format.')
+@click.option('--recovery', type=bool, is_flag=True, default=False,
+              help='Continue a previous migration that did not complete successfully.')
+@click.option('--reuse-partitions', type=bool, is_flag=True, default=False,
+              help="Perform a dry migration without moving partitions. "
+                   "Both clusters must share the bucket(s) where the partitions are stored.")
+@click.option('--workers', type=click.IntRange(1, 50), default=10,
+              help='Number of worker threads to use for migrating partitions. Default is 10.')
+@click.pass_context
+@report_error_and_exit(exctype=Exception)
+def migrate(ctx: click.Context, target_profile_name: str, target_hostname: str,
+            target_username: str, target_password: str, target_uri_scheme: str,
+            source_table: str, target_table: str, allow_merge: bool, only: str,
+            min_timestamp: datetime, max_timestamp: datetime, recovery: bool,
+            reuse_partitions: bool, workers: int):
+    source_profile = ctx.parent.obj['usercontext']
+
+    if (target_profile_name is None and
+            not (target_hostname or target_username or target_password or target_uri_scheme)):
+        if reuse_partitions:
+            raise click.BadParameter(
+                '--reuse-partitions must be used for migrations between different clusters.')
+        target_profile = copy.deepcopy(source_profile)
+
+    elif (target_profile_name or
+          (target_hostname and target_username and target_password and target_uri_scheme)):
+        target_profile = get_target_profile(target_profile_name, target_hostname,
+                                            target_username, target_password, target_uri_scheme,
+                                            source_profile.timeout)
+
+    else:
+        raise click.BadParameter(
+            'The data provided is incorrect. Please check your input and try again.')
+
+    logger.info(f'{" Preparing Migration ":=^50}')
+    # Source table name
+    source_resources = source_table.split('.')
+    source_profile.projectname = source_resources[0]
+    source_profile.tablename = source_resources[1]
+
+    # Target table name
+    target_resources = target_table.split('.')
+    target_profile.projectname = target_resources[0]
+    target_profile.tablename = target_resources[1]
+
+    source_data = MigrationData()
+    target_data = MigrationData()
+
+    # Obtaining resources to migrate
+    # Source
+    get_resources(source_profile, source_data)
+    # Target
+    only_storages = not (only == 'data' or recovery)
+    get_resources(target_profile, target_data, only_storages=only_storages)
+
+    if only != 'resources':
+        # Getting catalog
+        catalog = get_catalog(source_profile, source_data)
+        # Running validations
+        validates(source_profile, source_data, target_data, catalog,
+                  min_timestamp, max_timestamp, allow_merge, reuse_partitions)
+
+    logger.info('')
+
+    # Migrations
+    if only == 'resources' and not recovery:
+        creating_resources(target_profile, target_data, source_data, reuse_partitions)
+    elif only == 'data' or recovery:
+        migrate_data(target_profile, target_data, source_data.storages,
+                     catalog, workers, recovery, reuse_partitions)
+    else:
+        creating_resources(target_profile, target_data, source_data, reuse_partitions)
+        migrate_data(target_profile, target_data, source_data.storages,
+                     catalog, workers, recovery, reuse_partitions)
+
+    logger.info(f'{" Migration Process Completed ":=^50}')
+    logger.info('')

--- a/src/hdx_cli/cli_interface/migrate/data.py
+++ b/src/hdx_cli/cli_interface/migrate/data.py
@@ -1,0 +1,114 @@
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from queue import Queue
+
+from hdx_cli.cli_interface.migrate.helpers import (print_summary, validate_files_amount,
+                                                   confirm_migration, MigrationData,
+                                                   show_progress_bar, set_catalog)
+from hdx_cli.cli_interface.migrate.recovery import recovery_process
+from hdx_cli.cli_interface.migrate.workers import CountingQueue, ReaderWorker, WriterWorker
+from hdx_cli.library_api.common.catalog import Catalog
+from hdx_cli.library_api.common.context import ProfileUserContext
+from hdx_cli.library_api.common.provider import get_provider
+from hdx_cli.library_api.common.logging import get_logger
+
+logger = get_logger()
+
+
+def show_and_confirm_data_migration(catalog: Catalog, migrated_file_list: list) -> bool:
+    # General files information
+    total_rows, total_files, total_size = catalog.get_summary_information()
+    # Migrated files
+    migrated_files_count = len(migrated_file_list)
+    # Show it
+    print_summary(total_rows, total_files, total_size, migrated_files_count)
+    return validate_files_amount(total_files, migrated_files_count) and confirm_migration()
+
+
+def migrate_data(target_profile: ProfileUserContext, target_data: MigrationData,
+                 source_storages: list[dict], catalog: Catalog, workers_amount: int,
+                 recovery: bool = False, reuse_partitions: bool = False) -> None:
+    logger.info(f'{" Data ":=^50}')
+
+    if not reuse_partitions:
+        partition_paths_by_storage = catalog.get_partition_files_by_storage()
+        partitions_size = catalog.get_total_size()
+
+        # Migrating partitions
+        migrated_files_queue = Queue()
+        writer_queue = Queue()
+        exceptions = Queue()
+
+        workers_list = []
+        providers = {}
+        files_count = 0
+
+        migrated_file_list = []
+        # Recovery point if exist
+        if recovery:
+            target_root_path = f'db/hdx/{target_data.get_project_id()}/{target_data.get_table_id()}'
+            target_provider = get_provider(providers, target_data.storages)
+
+            logger.info(f"{'Looking migrated files':<42} -> [!n]")
+            migrated_file_list = target_provider.list_files_in_path(path=target_root_path)
+            logger.info('Done')
+
+        for storage_id, files_to_migrate in partition_paths_by_storage.items():
+            # Creating data providers
+            try:
+                source_provider = get_provider(providers, source_storages, storage_id)
+                target_provider = get_provider(providers, target_data.storages)
+            except Exception as exc:
+                exceptions.put(exc)
+                raise
+
+            # Total amount of files to migrate
+            files_count += len(files_to_migrate)
+
+            # Are there files already migrated?
+            if migrated_file_list:
+                files_to_migrate = recovery_process(files_to_migrate, migrated_file_list,
+                                                    migrated_files_queue)
+
+            reader_queue = CountingQueue(files_to_migrate)
+            for _ in range(workers_amount):
+                workers_list.append(
+                    ReaderWorker(reader_queue, writer_queue, exceptions,  source_provider,
+                                 workers_amount,  target_data.get_project_id(),
+                                 target_data.get_table_id())
+                )
+                workers_list.append(
+                    WriterWorker(
+                        writer_queue, migrated_files_queue, exceptions, target_provider)
+                )
+
+        # Before start the migration, show and ask for confirmation
+        if not show_and_confirm_data_migration(catalog, migrated_file_list):
+            logger.info(f'{" Migration Process Finished ":=^50}')
+            logger.info('')
+            sys.exit(0)
+
+        # Start all workers once confirmed by the user
+        with ThreadPoolExecutor(max_workers=workers_amount * 2) as executor:
+            future_to_worker = {executor.submit(worker.start): worker for worker in workers_list}
+
+            # Show progress bar while workers are running
+            show_progress_bar(partitions_size, migrated_files_queue, exceptions)
+
+            # Signal writers to stop by putting 'None' in the queue
+            for _ in range(workers_amount * len(partition_paths_by_storage)):
+                writer_queue.put(None)
+
+            # Wait for all workers to complete
+            for future in as_completed(future_to_worker):
+                try:
+                    future.result()
+                except Exception as exc:
+                    exceptions.put(exc)
+
+        if exceptions.qsize() != 0:
+            exception = exceptions.get()
+            raise exception
+
+    set_catalog(target_profile, target_data, catalog, reuse_partitions)
+    logger.info('')

--- a/src/hdx_cli/cli_interface/migrate/helpers.py
+++ b/src/hdx_cli/cli_interface/migrate/helpers.py
@@ -1,0 +1,213 @@
+import time
+from dataclasses import dataclass, field
+from datetime import datetime
+from queue import Queue
+from typing import Optional, Dict, List
+
+from tqdm import tqdm
+
+from hdx_cli.library_api.common.catalog import Catalog
+from hdx_cli.library_api.common.context import ProfileUserContext
+from hdx_cli.library_api.common.storage import get_storage_default
+from hdx_cli.library_api.common.logging import get_logger
+
+logger = get_logger()
+
+
+@dataclass
+class MigrationData:
+    project: Optional[Dict] = field(default_factory=dict)
+    table: Optional[Dict] = field(default_factory=dict)
+    transforms: List[Dict] = field(default_factory=list)
+    storages: List[Dict] = field(default_factory=list)
+
+    def get_project_id(self) -> Optional[str]:
+        if self.project is None:
+            return None
+        return self.project.get('uuid')
+
+    def get_table_id(self) -> Optional[str]:
+        if self.table is None:
+            return None
+        return self.table.get('uuid')
+
+
+def get_catalog(profile: ProfileUserContext, data: MigrationData) -> Catalog:
+    logger.info(
+        f"{f'Downloading catalog of {profile.projectname}.{profile.tablename}':<42} -> [!n]")
+    catalog = Catalog()
+    catalog.download(profile, data.get_project_id(), data.get_table_id())
+    logger.info('Done')
+    return catalog
+
+
+def set_catalog(profile: ProfileUserContext, data: MigrationData,
+                catalog: Catalog, reuse_partitions: bool) -> None:
+    logger.info(f"{f'Uploading catalog for {profile.projectname}.{profile.tablename}':<42} -> [!n]")
+    if not reuse_partitions:
+        target_default_storage_id, _ = get_storage_default(data.storages)
+        catalog.update(data.get_project_id(), data.get_table_id(), target_default_storage_id)
+    catalog.upload(profile)
+    logger.info('Done')
+
+
+def filter_catalog(catalog: Catalog, start_date: datetime = False,
+                   end_date: datetime = False) -> None:
+    if not (start_date or end_date):
+        return
+
+    logger.info(f"{'  Filtering catalog by timestamp':<42} -> [!n]")
+    catalog.filter_by_timestamp(start_date, end_date)
+    logger.info('Done')
+
+
+def bytes_to_mb(amount: int) -> float:
+    return round(amount / (1024 * 1024), 2)
+
+
+def show_progress_bar(total_bytes: int, migrated_files_queue: Queue, exceptions: Queue) -> None:
+    progress_bar = tqdm(total=total_bytes, desc='Copying ',
+                        bar_format="{desc}{bar:15} {percentage:3.0f}%| Elapsed time: {elapsed}")
+    total_bytes_processed = 0
+    total_files_processed = 0
+    while total_bytes_processed < total_bytes:
+        if migrated_files_queue.qsize() != 0:
+            _, bytes_size = migrated_files_queue.get()
+            progress_bar.update(bytes_size)
+            total_bytes_processed += bytes_size
+            total_files_processed += 1
+        else:
+            time.sleep(1)
+
+        if not exceptions.empty():
+            progress_bar.set_description(desc="Error ")
+            break
+    progress_bar.close()
+
+
+def confirm_migration(prompt: str = 'Continue with migration?') -> bool:
+    while True:
+        logger.info(f'{prompt} (yes/no): [!i]')
+        response = input().strip().lower()
+        if response in ['yes', 'no']:
+            return response == 'yes'
+        logger.info("Invalid input. Please enter 'yes' or 'no'.")
+
+
+# def show_and_confirm_migration(catalog: Catalog, migrated_file_list: list) -> bool:
+#     # General files information
+#     total_rows, total_files, total_size = catalog.get_summary_information()
+#     # Migrated files
+#     migrated_files_count = len(migrated_file_list)
+#     # Show it
+#     print_summary(total_rows, total_files, total_size, migrated_files_count)
+#     return validate_files_amount(total_files, migrated_files_count) and confirm_migration()
+
+
+def print_summary(total_rows: int, total_files: int, total_size: int,
+                  migrated_files_count: int = None) -> None:
+    logger.info('')
+    logger.info(f'{" Summary ":=^30}')
+    logger.info(f'- Total rows: {total_rows}')
+    logger.info(f'- Total files: {total_files}')
+    logger.info(f'- Total size: {bytes_to_mb(total_size)} MB')
+    logger.info('')
+    if migrated_files_count:
+        logger.info(f'- Files already migrated: {migrated_files_count}')
+
+
+def validate_files_amount(total_files: int, migrated_files: int) -> bool:
+    result = True
+    if total_files - migrated_files <= 0:
+        logger.info('No files to migrate.')
+        logger.info('')
+        result = False
+    return result
+
+
+# def migrate_data(target_profile: ProfileUserContext, target_data: MigrationData,
+#                  source_storages: list[dict], catalog: Catalog, workers_amount: int,
+#                  recovery: bool = False, reuse_partitions: bool = False) -> None:
+#     logger.info(f'{" Data ":=^50}')
+#
+#     if not reuse_partitions:
+#         partition_paths_by_storage = catalog.get_partition_files_by_storage()
+#         partitions_size = catalog.get_total_size()
+#
+#         # Migrating partitions
+#         migrated_files_queue = Queue()
+#         writer_queue = Queue()
+#         exceptions = Queue()
+#
+#         workers_list = []
+#         providers = {}
+#         files_count = 0
+#
+#         migrated_file_list = []
+#         # Recovery point if exist
+#         if recovery:
+#             target_root_path = f'db/hdx/{target_data.get_project_id()}/{target_data.get_table_id()}'
+#             target_provider = get_provider(providers, target_data.storages)
+#
+#             logger.info(f"{'Looking migrated files':<42} -> [!n]")
+#             migrated_file_list = target_provider.list_files_in_path(path=target_root_path)
+#             logger.info('Done')
+#
+#         for storage_id, files_to_migrate in partition_paths_by_storage.items():
+#             # Creating data providers
+#             try:
+#                 source_provider = get_provider(providers, source_storages, storage_id)
+#                 target_provider = get_provider(providers, target_data.storages)
+#             except Exception as exc:
+#                 exceptions.put(exc)
+#                 raise
+#
+#             # Total amount of files to migrate
+#             files_count += len(files_to_migrate)
+#
+#             # Are there files already migrated?
+#             if migrated_file_list:
+#                 files_to_migrate = recovery_process(files_to_migrate, migrated_file_list, migrated_files_queue)
+#
+#             reader_queue = CountingQueue(files_to_migrate)
+#             for _ in range(workers_amount):
+#                 workers_list.append(
+#                     ReaderWorker(reader_queue, writer_queue, exceptions,  source_provider,
+#                                  workers_amount,  target_data.get_project_id(), target_data.get_table_id())
+#                 )
+#                 workers_list.append(
+#                     WriterWorker(
+#                         writer_queue, migrated_files_queue, exceptions, target_provider)
+#                 )
+#
+#         # Before start the migration, show and ask for confirmation
+#         if not show_and_confirm_migration(catalog, migrated_file_list):
+#             logger.info(f'{" Migration Process Finished ":=^50}')
+#             logger.info('')
+#             sys.exit(0)
+#
+#         # Start all workers once confirmed by the user
+#         with ThreadPoolExecutor(max_workers=workers_amount * 2) as executor:
+#             future_to_worker = {executor.submit(worker.start): worker for worker in workers_list}
+#
+#             # Show progress bar while workers are running
+#             show_progress_bar(partitions_size, migrated_files_queue, exceptions)
+#
+#             # Signal writers to stop by putting `None` in the queue
+#             for _ in range(workers_amount * len(partition_paths_by_storage)):
+#                 writer_queue.put(None)
+#
+#             # Wait for all workers to complete
+#             for future in as_completed(future_to_worker):
+#                 # worker = future_to_worker[future]
+#                 try:
+#                     future.result()
+#                 except Exception as exc:
+#                     exceptions.put(exc)
+#
+#         if exceptions.qsize() != 0:
+#             exception = exceptions.get()
+#             raise exception
+#
+#     set_catalog(target_profile, target_data, catalog, reuse_partitions)
+#     logger.info('')

--- a/src/hdx_cli/cli_interface/migrate/helpers.py
+++ b/src/hdx_cli/cli_interface/migrate/helpers.py
@@ -94,16 +94,6 @@ def confirm_migration(prompt: str = 'Continue with migration?') -> bool:
         logger.info("Invalid input. Please enter 'yes' or 'no'.")
 
 
-# def show_and_confirm_migration(catalog: Catalog, migrated_file_list: list) -> bool:
-#     # General files information
-#     total_rows, total_files, total_size = catalog.get_summary_information()
-#     # Migrated files
-#     migrated_files_count = len(migrated_file_list)
-#     # Show it
-#     print_summary(total_rows, total_files, total_size, migrated_files_count)
-#     return validate_files_amount(total_files, migrated_files_count) and confirm_migration()
-
-
 def print_summary(total_rows: int, total_files: int, total_size: int,
                   migrated_files_count: int = None) -> None:
     logger.info('')
@@ -123,91 +113,3 @@ def validate_files_amount(total_files: int, migrated_files: int) -> bool:
         logger.info('')
         result = False
     return result
-
-
-# def migrate_data(target_profile: ProfileUserContext, target_data: MigrationData,
-#                  source_storages: list[dict], catalog: Catalog, workers_amount: int,
-#                  recovery: bool = False, reuse_partitions: bool = False) -> None:
-#     logger.info(f'{" Data ":=^50}')
-#
-#     if not reuse_partitions:
-#         partition_paths_by_storage = catalog.get_partition_files_by_storage()
-#         partitions_size = catalog.get_total_size()
-#
-#         # Migrating partitions
-#         migrated_files_queue = Queue()
-#         writer_queue = Queue()
-#         exceptions = Queue()
-#
-#         workers_list = []
-#         providers = {}
-#         files_count = 0
-#
-#         migrated_file_list = []
-#         # Recovery point if exist
-#         if recovery:
-#             target_root_path = f'db/hdx/{target_data.get_project_id()}/{target_data.get_table_id()}'
-#             target_provider = get_provider(providers, target_data.storages)
-#
-#             logger.info(f"{'Looking migrated files':<42} -> [!n]")
-#             migrated_file_list = target_provider.list_files_in_path(path=target_root_path)
-#             logger.info('Done')
-#
-#         for storage_id, files_to_migrate in partition_paths_by_storage.items():
-#             # Creating data providers
-#             try:
-#                 source_provider = get_provider(providers, source_storages, storage_id)
-#                 target_provider = get_provider(providers, target_data.storages)
-#             except Exception as exc:
-#                 exceptions.put(exc)
-#                 raise
-#
-#             # Total amount of files to migrate
-#             files_count += len(files_to_migrate)
-#
-#             # Are there files already migrated?
-#             if migrated_file_list:
-#                 files_to_migrate = recovery_process(files_to_migrate, migrated_file_list, migrated_files_queue)
-#
-#             reader_queue = CountingQueue(files_to_migrate)
-#             for _ in range(workers_amount):
-#                 workers_list.append(
-#                     ReaderWorker(reader_queue, writer_queue, exceptions,  source_provider,
-#                                  workers_amount,  target_data.get_project_id(), target_data.get_table_id())
-#                 )
-#                 workers_list.append(
-#                     WriterWorker(
-#                         writer_queue, migrated_files_queue, exceptions, target_provider)
-#                 )
-#
-#         # Before start the migration, show and ask for confirmation
-#         if not show_and_confirm_migration(catalog, migrated_file_list):
-#             logger.info(f'{" Migration Process Finished ":=^50}')
-#             logger.info('')
-#             sys.exit(0)
-#
-#         # Start all workers once confirmed by the user
-#         with ThreadPoolExecutor(max_workers=workers_amount * 2) as executor:
-#             future_to_worker = {executor.submit(worker.start): worker for worker in workers_list}
-#
-#             # Show progress bar while workers are running
-#             show_progress_bar(partitions_size, migrated_files_queue, exceptions)
-#
-#             # Signal writers to stop by putting `None` in the queue
-#             for _ in range(workers_amount * len(partition_paths_by_storage)):
-#                 writer_queue.put(None)
-#
-#             # Wait for all workers to complete
-#             for future in as_completed(future_to_worker):
-#                 # worker = future_to_worker[future]
-#                 try:
-#                     future.result()
-#                 except Exception as exc:
-#                     exceptions.put(exc)
-#
-#         if exceptions.qsize() != 0:
-#             exception = exceptions.get()
-#             raise exception
-#
-#     set_catalog(target_profile, target_data, catalog, reuse_partitions)
-#     logger.info('')

--- a/src/hdx_cli/cli_interface/migrate/recovery.py
+++ b/src/hdx_cli/cli_interface/migrate/recovery.py
@@ -1,0 +1,25 @@
+from queue import Queue
+
+
+def recovery_process(files_to_migrate: list, migrated_files: list,
+                     migrated_files_queue: Queue) -> list[tuple[str, int]]:
+    """
+    The objective of this method is to remove from 'files_to_migrate' list
+    the files that have already been migrated and are already in the bucket,
+    comparing with 'migrated_files' list.
+
+    :param files_to_migrate: List of tuples, each containing (file_path, data_size)
+                             representing files to migrate
+    :param migrated_files: List of root paths of files that were already migrated
+    :param migrated_files_queue: Queue of files migrated during the current run
+    :return: A new list of file paths to migrate, excluding those that have already been migrated
+    """
+    new_file_paths = []
+    for path, data_size in files_to_migrate:
+        _, _, data_path = path.partition('/data/v2/current/')
+        if data_path in migrated_files:
+            migrated_files_queue.put((path, data_size))
+        else:
+            new_file_paths.append((path, data_size))
+
+    return new_file_paths

--- a/src/hdx_cli/cli_interface/migrate/resources.py
+++ b/src/hdx_cli/cli_interface/migrate/resources.py
@@ -1,0 +1,105 @@
+import copy
+import json
+from urllib.parse import urlparse
+
+from hdx_cli.cli_interface.common.undecorated_click_commands import basic_create_with_body_from_string
+from hdx_cli.library_api.common.exceptions import HttpException, ResourceNotFoundException
+from hdx_cli.library_api.common.generic_resource import access_resource_detailed
+from hdx_cli.library_api.common.logging import get_logger
+
+logger = get_logger()
+
+
+def creating_resources(target_profile, target_data, source_data, reuse_partitions: bool = False) -> None:
+    logger.info(f'{" Resources ":=^50}')
+    logger.info(f'Creating resources in {target_profile.hostname}')
+
+    # PROJECT
+    logger.info(f"{f'  Project: {target_profile.projectname}':<42} -> [!n]")
+    _, target_projects_url = access_resource_detailed(target_profile, [('projects', None)])
+    target_projects_path = urlparse(f'{target_projects_url}').path
+
+    source_project_body = copy.deepcopy(source_data.project)
+    try:
+        if not reuse_partitions:
+            del source_project_body['uuid']
+        basic_create_with_body_from_string(target_profile,
+                                           target_projects_path,
+                                           target_profile.projectname,
+                                           json.dumps(source_project_body))
+        logger.info('Done')
+    except HttpException as exc:
+        if exc.error_code != 400 or 'already exists' not in str(exc.message):
+            raise exc
+        logger.info('Exists, skipping')
+
+    # Getting project body and project_url of the already created project
+    target_data.project, target_project_url = access_resource_detailed(target_profile,
+                                                                       [('projects', target_profile.projectname)])
+
+    # TABLE
+    logger.info(f"{f'  Table: {target_profile.tablename}':<42} -> [!n]")
+    target_tables_path = urlparse(f'{target_project_url}tables/').path
+    table_body = copy.deepcopy(source_data.table)
+    if not reuse_partitions:
+        del table_body['uuid']
+    basic_create_with_body_from_string(target_profile,
+                                       target_tables_path,
+                                       target_profile.tablename,
+                                       json.dumps(table_body))
+    logger.info('Done')
+
+    # Getting table body and table_url of the already created table
+    target_data.table, target_table_url = access_resource_detailed(target_profile,
+                                                                   [('projects', target_profile.projectname),
+                                                                    ('tables', target_profile.tablename)])
+
+    # TRANSFORMS
+    transform_names = ','.join(list(map(lambda t: t['name'], source_data.transforms)))
+    logger.info(f"{f'  Transforms: {transform_names}':<42} -> [!n]")
+    target_transforms_path = urlparse(f'{target_table_url}transforms/').path
+    for transform in source_data.transforms:
+        del transform['uuid']
+        transform_name = transform.get('name')
+        basic_create_with_body_from_string(target_profile,
+                                           target_transforms_path,
+                                           transform_name,
+                                           json.dumps(transform))
+    logger.info('Done')
+    logger.info('')
+
+
+def get_resources(profile, data, only_storages=False) -> None:
+    logger.info(f"{f'Getting resources from {profile.hostname}':<50}")
+
+    if not only_storages:
+        logger.info(f'{f"  Project: {profile.projectname}":<42} -> [!n]')
+        data.project, _ = access_resource_detailed(profile, [('projects', profile.projectname)])
+        if not data.project:
+            raise ResourceNotFoundException(f"The project '{profile.projectname}' was not found.")
+        logger.info('Done')
+
+        logger.info(f"{f'  Table: {profile.tablename}':<42} -> [!n]")
+        data.table, _ = access_resource_detailed(profile, [('projects', profile.projectname),
+                                                           ('tables', profile.tablename)])
+        if not data.table:
+            raise ResourceNotFoundException(f"The table '{profile.tablename}' was not found.")
+        logger.info('Done')
+
+        logger.info(f"{'  Transforms: '}[!n]")
+        data.transforms, _ = access_resource_detailed(profile, [('projects', profile.projectname),
+                                                                ('tables', profile.tablename),
+                                                                ('transforms', None)])
+        if not data.transforms:
+            raise ResourceNotFoundException(
+                f"Transforms in the table '{profile.tablename}' were not found.")
+        transform_names = ','.join(list(map(lambda t: t['name'], data.transforms)))
+        logger.info(f'{transform_names:<28} -> [!n]')
+        logger.info('Done')
+
+    # Then, storages
+    logger.info(f"{'  Storages: ':}[!n]")
+    data.storages, _ = access_resource_detailed(profile, [('storages', None)])
+    storage_names = ','.join(list(map(lambda t: t['name'], data.storages)))
+    logger.info(f'{storage_names:<30} -> [!n]')
+    logger.info('Done')

--- a/src/hdx_cli/cli_interface/migrate/validator.py
+++ b/src/hdx_cli/cli_interface/migrate/validator.py
@@ -1,0 +1,70 @@
+from datetime import datetime
+
+from hdx_cli.cli_interface.common.undecorated_click_commands import get_resource_list
+from hdx_cli.cli_interface.migrate.helpers import MigrationData
+from hdx_cli.library_api.common.catalog import Catalog
+from hdx_cli.library_api.common.context import ProfileUserContext
+from hdx_cli.library_api.common.storage import equivalent_storages
+from hdx_cli.library_api.common.logging import get_logger
+
+logger = get_logger()
+
+
+def validates(source_profile: ProfileUserContext, source_data: MigrationData,
+              target_data: MigrationData, catalog: Catalog, min_timestamp: datetime,
+              max_timestamp: datetime, allow_merge: bool, reuse_partitions: bool) -> None:
+    logger.info("Running some validations")
+    table_constraints(source_profile, source_data.table, allow_merge)
+    filter_catalog(catalog, min_timestamp, max_timestamp)
+    validate_reuse_partitions(source_data.storages, target_data.storages, catalog, reuse_partitions)
+
+
+def table_constraints(profile: ProfileUserContext, table_body: dict, allow_merge=False) -> None:
+    # Validate if 'merge' is not enabled in the settings table
+    # Or if the user passed the '--allow-merge' option
+    logger.info(f"{'  Checking merge table settings':<42} -> [!n]")
+    if not allow_merge and is_merge_enable(table_body):
+        raise Exception(f"The merging process is enabled in the '{profile.tablename}' table. "
+                        "To successfully migrate data, be sure to disable it or use --allow-merge "
+                        "to skip this validation.")
+    logger.info(f'{"Done" if not allow_merge else "Skip due to --allow-merge"}')
+
+    # Validate if the table to be migrated has an alter job in a running state
+    logger.info(f"{'  Looking for running alter jobs':<42} -> [!n]")
+    alter_path = f'/config/v1/orgs/{profile.org_id}/jobs/alter/'
+    alter_jobs = get_resource_list(profile, alter_path).get('results')
+    is_alter_job_running = list(filter(
+        lambda x: x.get('status') == 'running' and
+                  x.get('settings', {}).get('project_name') == profile.projectname and
+                  x.get('settings', {}).get('table_name') == profile.tablename,
+        alter_jobs))
+    if is_alter_job_running:
+        raise Exception(f"There is an alter job running on the '{profile.tablename}' table. "
+                        "To successfully migrate data, be sure there are not alter job processes "
+                        "running on this table.")
+    logger.info('Done')
+
+
+def is_merge_enable(table_body: dict) -> bool:
+    return table_body.get('settings', {}).get('merge', {}).get('enabled')
+
+
+def filter_catalog(catalog: Catalog, min_timestamp: datetime = False,
+                   max_timestamp: datetime = False) -> None:
+    if not (min_timestamp or max_timestamp):
+        return
+
+    logger.info(f"{'  Filtering catalog by timestamp':<42} -> [!n]")
+    catalog.filter_by_timestamp(min_timestamp, max_timestamp)
+    logger.info('Done')
+
+
+def validate_reuse_partitions(source_storages: list[dict], target_storages: list[dict],
+                              catalog: Catalog, reuse_partitions: bool = False) -> None:
+    if not reuse_partitions:
+        return
+
+    logger.info(f"{'  Updating catalog':<42} -> [!n]")
+    storage_equivalences = equivalent_storages(source_storages, target_storages)
+    catalog.update_equivalent_storage(storage_equivalences)
+    logger.info('Done')

--- a/src/hdx_cli/cli_interface/migrate/workers.py
+++ b/src/hdx_cli/cli_interface/migrate/workers.py
@@ -1,0 +1,81 @@
+import threading
+import time
+from queue import Queue
+
+from hdx_cli.library_api.provider import BaseProvider
+
+
+class CountingQueue(Queue):
+    def __init__(self, elements: list = None):
+        super().__init__()
+        if elements is not None:
+            for element in elements:
+                self.put(element)
+
+
+class ReaderWorker(threading.Thread):
+    def __init__(self, reader_queue: Queue, writer_queue: Queue, exceptions: Queue,
+                 provider: BaseProvider, workers_amount: int, target_project_id=None,
+                 target_table_id=None):
+        threading.Thread.__init__(self)
+        self.reader_queue = reader_queue
+        self.writer_queue = writer_queue
+        self.exceptions = exceptions
+        self.provider = provider
+        self.workers_amount = workers_amount
+        self.target_project_id = target_project_id
+        self.target_table_id = target_table_id
+
+    def run(self):
+        try:
+            while True:
+                # If there are exceptions or the work queue is empty, it stops.
+                if not self.exceptions.empty() or self.reader_queue.empty():
+                    break
+
+                # Queue for writers is too full
+                # Preserve memory space
+                if self.writer_queue.qsize() > (self.workers_amount * 2):
+                    time.sleep(1)
+                    continue
+
+                path, data_size = self.reader_queue.get()
+                data = self.provider.read_file(path)
+
+                # Migrating partitions into a different root_path (project/table)
+                if self.target_project_id and self.target_table_id:
+                    split_path = path.split('/')
+                    split_path[2] = self.target_project_id
+                    split_path[3] = self.target_table_id
+                    path = "/".join(split_path)
+
+                self.writer_queue.put((path, data, data_size))
+        except Exception as exc:
+            self.exceptions.put(exc)
+
+
+class WriterWorker(threading.Thread):
+    def __init__(self, writer_queue: Queue, migrated_files_queue: Queue, exceptions: Queue,
+                 provider: BaseProvider):
+        threading.Thread.__init__(self)
+        self.writer_queue = writer_queue
+        self.migrated_files_queue = migrated_files_queue
+        self.exceptions = exceptions
+        self.provider = provider
+
+    def run(self):
+        try:
+            while True:
+                if not self.exceptions.empty():
+                    return
+
+                item = self.writer_queue.get()
+                if item is None:
+                    return
+                path, data, data_size = item
+
+                self.provider.write_file(path, data)
+                self.migrated_files_queue.put((path, data_size))
+                self.writer_queue.task_done()
+        except Exception as exc:
+            self.exceptions.put(exc)

--- a/src/hdx_cli/library_api/common/catalog.py
+++ b/src/hdx_cli/library_api/common/catalog.py
@@ -1,0 +1,177 @@
+import csv
+import io
+import json
+from datetime import datetime
+from functools import reduce
+
+from hdx_cli.library_api.common import rest_operations as rest_ops
+from hdx_cli.library_api.common.exceptions import (ResourceNotFoundException, HttpException,
+                                                   HdxCliException, CatalogException)
+
+TIMESTAMP_FORMAT = '%Y-%m-%d %H:%M:%S'
+
+
+def _get_metadata(metadata):
+    return json.dumps(metadata)
+
+
+def _set_metadata(metadata):
+    return json.loads(metadata.replace("'", '"'))
+
+
+class Partition:
+    def __init__(self, values):
+        self.created = values[0]
+        self.modified = values[1]
+        self.min_timestamp = values[2]
+        self.max_timestamp = values[3]
+        self.manifest_size = values[4]
+        self.data_size = values[5]
+        self.index_size = values[6]
+        self.root_path = values[7]
+        self.data_path = values[8]
+        self.active = values[9]
+        self.rows = values[10]
+        self.mem_size = values[11]
+        self.metadata = _set_metadata(values[12])
+        self.shard_key = values[13]
+        self.lock = values[14]
+        self.storage_id = values[15]
+
+    def get_partition_path(self):
+        return "/".join([str(self.root_path).strip(), str(self.data_path).strip()])
+
+    def to_list(self):
+        return [self.created, self.modified, self.min_timestamp, self.max_timestamp,
+                self.manifest_size, self.data_size, self.index_size, self.root_path,
+                self.data_path, self.active, self.rows, self.mem_size,
+                _get_metadata(self.metadata), self.shard_key, self.lock, self.storage_id]
+
+    def get_manifest_size(self):
+        return int(self.manifest_size)
+
+    def get_index_size(self):
+        return int(self.index_size)
+
+    def get_data_size(self):
+        return int(self.data_size)
+
+    def get_partition_size(self):
+        return self.get_manifest_size() + self.get_index_size() + self.get_data_size()
+
+
+def _get_bytes_from_catalog(partitions: list[Partition]) -> bytes:
+    csv_buffer = io.StringIO()
+    csv_writer = csv.writer(csv_buffer)
+    for partition in partitions:
+        csv_writer.writerow(partition.to_list())
+
+    return csv_buffer.getvalue().encode('utf-8')
+
+
+def _get_catalog_from_bytes(file: bytes) -> list[Partition]:
+    csv_catalog = io.StringIO(file.decode('utf-8'))
+    reader = csv.reader(csv_catalog, delimiter=',')
+    # Jump csv header
+    reader.__next__()
+    return [Partition(row) for row in reader]
+
+
+class Catalog:
+    def __init__(self):
+        self.partitions = []
+        self.total_size = 0
+
+    def download(self, profile, project_id, table_id) -> None:
+        download_catalog_url = (
+            f'{profile.scheme}://{profile.hostname}/config/v1/orgs/{profile.org_id}/'
+            f'catalog/download/?project={project_id}&table={table_id}')
+        headers = {'Authorization': f"{profile.auth.token_type} {profile.auth.token}",
+                   'Accept': 'application/json'}
+        try:
+            catalog = rest_ops.get(download_catalog_url, headers=headers, fmt='csv', timeout=180)
+            self.partitions = _get_catalog_from_bytes(catalog)
+        except HttpException as exc:
+            raise HdxCliException(f"The Hydrolix version in the '{profile.hostname}' hostname "
+                                  f"does not support catalog endpoint.") from exc
+
+    def upload(self, profile) -> None:
+        upload_catalog_url = (
+            f'{profile.scheme}://{profile.hostname}/config/v1/orgs/{profile.org_id}/'
+            f'catalog/upload/?header=no')
+        headers = {'Authorization': f"{profile.auth.token_type} {profile.auth.token}",
+                   'Accept': 'application/json'}
+
+        catalog_file = _get_bytes_from_catalog(self.partitions)
+        rest_ops.create_file(upload_catalog_url, headers=headers, file_stream=catalog_file,
+                             timeout=300, remote_filename=None)
+
+    def update(self, project_uuid: str, table_uuid: str, storage_uuid: str) -> None:
+        for partition in self.partitions:
+            partition.root_path = f'{project_uuid}/{table_uuid}'
+            partition.metadata['storage_id'] = f'{storage_uuid}'
+            partition.storage_id = f'{storage_uuid}'
+            # This mitigates problems when there was some deleted alter job, without cancellation.
+            partition.lock = None
+
+    def update_equivalent_storage(self, equivalent_storages: dict[str, str]) -> None:
+        for partition in self.partitions:
+            new_storage_uuid = equivalent_storages.get(partition.storage_id)
+
+            if not new_storage_uuid and not partition.storage_id:
+                new_storage_uuid = equivalent_storages.get('default')
+
+            if not new_storage_uuid:
+                raise ResourceNotFoundException(
+                    f"The storage with uuid '{partition.storage_id}' was not found "
+                    "in the destination cluster.")
+
+            partition.storage_id = new_storage_uuid
+            partition.metadata['storage_id'] = f'{new_storage_uuid}'
+            # This mitigates problems when there was some deleted alter job, without cancellation.
+            partition.lock = None
+
+    def filter_by_timestamp(self, min_timestamp: datetime, max_timestamp: datetime) -> None:
+        if not (min_timestamp or max_timestamp):
+            return
+
+        self.partitions = list(filter(
+            lambda item: (not min_timestamp or datetime.strptime(item.min_timestamp,
+                                                                 TIMESTAMP_FORMAT) >= min_timestamp) and
+                         (not max_timestamp or datetime.strptime(item.max_timestamp,
+                                                                 TIMESTAMP_FORMAT) <= max_timestamp),
+            self.partitions
+        ))
+
+        if not self.partitions:
+            raise CatalogException("No partitions found matching the given date range.")
+
+    def get_summary_information(self) -> tuple[int, int, int]:
+        row_count = reduce(lambda count, item: count + int(item.rows), self.partitions, 0)
+        return row_count, len(self.partitions) * 3, self.get_total_size()
+
+    def get_total_size(self) -> int:
+        if not self.total_size:
+            self.total_size = reduce(lambda count, item: count + item.get_partition_size(),
+                                     self.partitions, 0)
+
+        return self.total_size
+
+    def get_partition_files_by_storage(self) -> dict[str, list[tuple[str, int]]]:
+        partition_files_by_storage = {}
+        for partition in self.partitions:
+            split_path = partition.get_partition_path().split('/')
+            # Add 'db/hdx' to the partition path
+            split_path.insert(0, 'db/hdx')
+            partition_path = '/'.join(split_path)
+            partition_files_path = [(f'{partition_path}/manifest.hdx', partition.get_manifest_size()),
+                                    (f'{partition_path}/index.hdx', partition.get_index_size()),
+                                    (f'{partition_path}/data.hdx', partition.get_data_size())]
+
+            storage_id = partition.storage_id
+            if partition_files_by_storage.get(storage_id):
+                partition_files_by_storage[storage_id].extend(partition_files_path)
+            else:
+                partition_files_by_storage[storage_id] = partition_files_path
+
+        return partition_files_by_storage

--- a/src/hdx_cli/library_api/common/exceptions.py
+++ b/src/hdx_cli/library_api/common/exceptions.py
@@ -110,3 +110,40 @@ class InvalidEmailException(InvalidDataException):
 
 class QueryOptionNotFound(HdxCliException):
     pass
+
+
+class StorageNotFoundError(HdxCliException):
+    pass
+
+
+class ProviderError(HdxCliException):
+    """
+    Base exception class for Provider errors.
+    """
+    def __init__(self, message):
+        self.message = message
+        super().__init__(self.message)
+
+
+class CredentialsNotFoundError(ProviderError):
+    def __init__(self, message="Credentials not found."):
+        super().__init__(message)
+
+
+class InvalidCredentialsError(ProviderError):
+    def __init__(self, message="Invalid credentials."):
+        super().__init__(message)
+
+
+class CloudConnectionError(ProviderError):
+    def __init__(self, message="There was an error connecting to the cloud service."):
+        super().__init__(message)
+
+
+class ProviderClassNotFoundError(ProviderError):
+    def __init__(self, message):
+        super().__init__(message)
+
+
+class CatalogException(HdxCliException):
+    pass

--- a/src/hdx_cli/library_api/common/generic_resource.py
+++ b/src/hdx_cli/library_api/common/generic_resource.py
@@ -50,10 +50,12 @@ def access_resource_detailed(ctx: ProfileUserContext,
                                       timeout=timeout)
         if resource_name is None:
             return (resource_list, resource_url)
-        try:
-            a_resource = [r for r in resource_list if r['name'] == resource_name][0]
-        except:
-            raise
+
+        a_resource = [r for r in resource_list if r['name'] == resource_name]
+        if not a_resource:
+            return None, resource_url
+
+        a_resource = a_resource[0]
         resource_url = f'{resource_url}{a_resource["uuid"]}/'
     if not resource_kind_and_name:
         pass

--- a/src/hdx_cli/library_api/common/logging.py
+++ b/src/hdx_cli/library_api/common/logging.py
@@ -1,8 +1,17 @@
 import sys
 import logging
 
+logging.getLogger('boto3').setLevel(logging.CRITICAL)
+logging.getLogger('botocore').setLevel(logging.CRITICAL)
+logging.getLogger('urllib3').setLevel(logging.CRITICAL)
+logging.getLogger('azure.storage.blob').setLevel(logging.CRITICAL)
+logging.getLogger('azure.core.pipeline.policies.http_logging_policy').setLevel(logging.CRITICAL)
+logging.getLogger('google').setLevel(logging.CRITICAL)
+
 # key to have logging outputs without '\n' new line.
 SPECIAL_CODE = '[!n]'
+# key to use for input cases
+INPUT_SPECIAL_CODE = '[!i]'
 
 
 class InfoStreamHandler(logging.StreamHandler):
@@ -13,8 +22,8 @@ class InfoStreamHandler(logging.StreamHandler):
         return record.msg
 
     def emit(self, record):
-        if SPECIAL_CODE in record.msg:
-            record.msg = record.msg.replace(SPECIAL_CODE, '')
+        if SPECIAL_CODE in record.msg or INPUT_SPECIAL_CODE in record.msg:
+            record.msg = record.msg.replace(SPECIAL_CODE, '').replace(INPUT_SPECIAL_CODE, '')
             self.terminator = ''
         else:
             self.terminator = '\n'
@@ -25,19 +34,35 @@ class InfoStreamHandler(logging.StreamHandler):
 class DebugStreamHandler(logging.StreamHandler):
     def __init__(self, stream=None):
         super().__init__(stream or sys.stdout)
+        self.last_message_no_newline = False
 
     def format(self, record):
         formatter = logging.Formatter('%(asctime)s :: %(levelname)s :: %(message)s')
         return formatter.format(record)
 
     def emit(self, record):
-        if SPECIAL_CODE in record.msg:
-            record.msg = record.msg.replace(SPECIAL_CODE, '')
-            self.terminator = ''
-        else:
-            self.terminator = '\n'
+        try:
+            msg = self.format(record)
+            stream = self.stream
+            if SPECIAL_CODE in record.msg:
+                if self.last_message_no_newline:
+                    msg = record.getMessage().replace(SPECIAL_CODE, "")
+                else:
+                    self.last_message_no_newline = True
+                    msg = msg.replace(SPECIAL_CODE, "")
+            elif INPUT_SPECIAL_CODE in record.msg:
+                msg = msg.replace(INPUT_SPECIAL_CODE, "")
+            else:
+                if self.last_message_no_newline:
+                    self.last_message_no_newline = False
+                    msg = f'{record.getMessage()}\n'
+                else:
+                    msg = f'{msg}\n'
 
-        return super().emit(record)
+            stream.write(f"{msg}")
+            self.flush()
+        except Exception:
+            self.handleError(record)
 
 
 def set_debug_logger():

--- a/src/hdx_cli/library_api/common/login.py
+++ b/src/hdx_cli/library_api/common/login.py
@@ -24,11 +24,12 @@ def _do_login(username, hostname,
         result = req.post(url, json=login_data,
                           headers={'Accept': 'application/json'},
                           timeout=15)
+    except req.ConnectTimeout as exc:
+        raise HdxCliException("Timeout exception.") from exc
     except req.ConnectionError as exc:
         logger.error(f'{exc}')
-        raise LogicException(f"Connection error: could not stablish connection with host {hostname} (using {scheme}).") from exc
-    except req.ConnectTimeout as exc:
-        raise HdxCliException("Timeout exception.")
+        raise LogicException(
+            f"Connection error: could not stablish connection with host {hostname} (using {scheme}).") from exc
     else:
         if result.status_code != 200:
             raise LoginException(

--- a/src/hdx_cli/library_api/common/provider.py
+++ b/src/hdx_cli/library_api/common/provider.py
@@ -1,0 +1,39 @@
+from .exceptions import ProviderClassNotFoundError, StorageNotFoundError
+from ..provider import BaseProvider, AwsProvider, AzureProvider, GcpProvider, LinodeProvider
+from .storage import get_storage_by_id, get_storage_default
+
+
+def setup_provider(storage_settings: dict, credentials=None) -> BaseProvider:
+    if credentials is None:
+        credentials = {}
+
+    cloud = storage_settings.get('cloud').strip()
+    region = storage_settings.get('region').strip()
+    if cloud == 'aws':
+        cloud = 'linode'
+        region = 'us-iad-1'
+    bucket_name = storage_settings.get('bucket_name').strip()
+    bucket_path = storage_settings.get('bucket_path').strip()
+    provider_class_name = cloud.capitalize() + 'Provider'
+
+    if provider_class_name in globals():
+        provider_class = globals()[provider_class_name]
+        return provider_class(bucket_name, bucket_path, region).setup_connection_to_bucket(**credentials)
+
+    raise ProviderClassNotFoundError(f"Provider '{provider_class_name}' not found.")
+
+
+def get_provider(providers: dict, storages: list, storage_id=None, credentials=None) -> BaseProvider:
+    if credentials is None:
+        credentials = {}
+
+    storage_id, storage_settings = get_storage_by_id(storages, storage_id) if storage_id else get_storage_default(storages)
+    if provider := providers.get(storage_id):
+        return provider
+
+    if not storage_settings:
+        raise StorageNotFoundError(f"Storage id ({storage_id}) not found.")
+
+    provider = setup_provider(storage_settings, credentials)
+    providers[storage_id] = provider
+    return provider

--- a/src/hdx_cli/library_api/common/storage.py
+++ b/src/hdx_cli/library_api/common/storage.py
@@ -1,0 +1,50 @@
+from typing import Union, Tuple
+
+
+def _is_same_bucket(settings_source: dict, settings_target: dict) -> bool:
+    result = False
+    if (
+            settings_source.get('bucket_name') == settings_target.get('bucket_name') and
+            settings_source.get('bucket_path') == settings_target.get('bucket_path') and
+            settings_source.get('region') == settings_target.get('region') and
+            settings_source.get('cloud') == settings_target.get('cloud')
+    ):
+        result = True
+    return result
+
+
+def _look_for_same_bucket(settings: dict, storages: list[dict]) -> Union[str, None]:
+    for storage in storages:
+        if _is_same_bucket(settings, storage.get('settings')):
+            return storage.get('uuid')
+    return None
+
+
+def equivalent_storages(source_storages: list[dict], target_storages: list[dict]) -> dict[str, str]:
+    result_dict = {}
+    for source_storage in source_storages:
+        source_storage_settings = source_storage.get('settings')
+        target_storage_uuid = _look_for_same_bucket(source_storage_settings, target_storages)
+        if target_storage_uuid:
+            result_dict[source_storage.get('uuid')] = target_storage_uuid
+
+            # Default source storage added to map it when null storage_id values
+            # exist in catalog records
+            if source_storage_settings.get('is_default'):
+                result_dict['default'] = target_storage_uuid
+
+    return result_dict
+
+
+def get_storage_by_id(storages: list[dict], storage_id: str) -> Union[Tuple[str, dict], None]:
+    for storage in storages:
+        if storage.get('uuid') == storage_id:
+            return storage_id, storage.get('settings')
+    return None
+
+
+def get_storage_default(storages: list[dict]) -> Union[Tuple[str, dict], None]:
+    for storage in storages:
+        if storage.get('settings', {}).get('is_default'):
+            return storage.get('uuid'), storage.get('settings')
+    return None

--- a/src/hdx_cli/library_api/provider/__init__.py
+++ b/src/hdx_cli/library_api/provider/__init__.py
@@ -1,0 +1,13 @@
+from .base_provider import BaseProvider
+from .aws_provider import AwsProvider
+from .azure_provider import AzureProvider
+from .gcp_provider import GcpProvider
+from .linode_provider import LinodeProvider
+
+__all__ = [
+    "BaseProvider",
+    "AwsProvider",
+    "AzureProvider",
+    "GcpProvider",
+    "LinodeProvider"
+]

--- a/src/hdx_cli/library_api/provider/aws_provider.py
+++ b/src/hdx_cli/library_api/provider/aws_provider.py
@@ -1,0 +1,80 @@
+import boto3
+from botocore.exceptions import NoCredentialsError, ClientError
+
+from .base_provider import BaseProvider
+from ..common.exceptions import CloudConnectionError, CredentialsNotFoundError
+from ..common.logging import get_logger
+
+logger = get_logger()
+
+
+class AwsProvider(BaseProvider):
+    def __init__(self, bucket_name, bucket_path, region):
+        self.s3_client = None
+        self.bucket_name = bucket_name
+        self.region = region
+        partial_bucket_path = bucket_path[1:] if bucket_path.startswith('/') else bucket_path
+        self.bucket_path = partial_bucket_path + '/' if partial_bucket_path else partial_bucket_path
+
+    def setup_connection_to_bucket(self, **kwargs):
+        logger.info(f'Connecting to AWS bucket: {self.bucket_name}')
+
+        aws_access_key_id = kwargs.get('aws_access_key_id')
+        aws_secret_access_key = kwargs.get('aws_secret_access_key')
+        while not aws_access_key_id or not aws_secret_access_key:
+            logger.info('  Please enter your access key ID: [!i]')
+            aws_access_key_id = input().strip()
+            logger.info('  Please enter your secret access ID: [!i]')
+            aws_secret_access_key = input().strip()
+
+        try:
+            self.s3_client = boto3.client('s3',
+                                          aws_access_key_id=aws_access_key_id,
+                                          aws_secret_access_key=aws_secret_access_key)
+            self.s3_client.list_objects_v2(Bucket=self.bucket_name)
+            return self
+        except NoCredentialsError as exc:
+            raise CredentialsNotFoundError('AWS credentials not found. Please provide valid credentials.') from exc
+        except ClientError as exc:
+            error_code = exc.response['Error']['Code']
+            if error_code == 'AccessDenied':
+                raise PermissionError(
+                    f"Access denied to bucket '{self.bucket_name}'. Please check your permissions.") from exc
+            else:
+                raise CloudConnectionError(
+                    f"There was an error setting up connection to bucket '{self.bucket_name}': {exc}") from exc
+
+    def read_file(self, path: str) -> bytes:
+        try:
+            response = self.s3_client.get_object(Bucket=self.bucket_name, Key=f'{self.bucket_path}{path}')
+            return response['Body'].read()
+        except ClientError as exc:
+            error_code = exc.response['Error']['Code']
+            if error_code == 'NoSuchKey':
+                raise FileNotFoundError(f"File '{path}' not found in '{self.bucket_name}' bucket.") from exc
+            elif error_code == 'AccessDenied':
+                raise PermissionError(f"Access denied to read file '{path}' in '{self.bucket_name}' bucket.") from exc
+            else:
+                raise CloudConnectionError(f"There was an error reading file '{path}': {exc}") from exc
+        except NoCredentialsError as exc:
+            raise CredentialsNotFoundError() from exc
+
+    def write_file(self, path: str, data: bytes):
+        try:
+            self.s3_client.put_object(Bucket=self.bucket_name, Key=f'{self.bucket_path}{path}', Body=data)
+        except ClientError as exc:
+            raise CloudConnectionError(f"There was an error writing file '{path}': {exc}") from exc
+        except NoCredentialsError as exc:
+            raise CredentialsNotFoundError() from exc
+
+    def list_files_in_path(self, path: str) -> list:
+        response = self.s3_client.list_objects_v2(Bucket=self.bucket_name, Prefix=path)
+        file_paths = []
+        if 'Contents' in response:
+            for obj in response['Contents']:
+                # Only add file names, not directories
+                if not obj['Key'].endswith('/'):
+                    _, _, file_path = obj['Key'].partition('/data/v2/current/')
+                    file_paths.append(file_path)
+
+        return file_paths

--- a/src/hdx_cli/library_api/provider/azure_provider.py
+++ b/src/hdx_cli/library_api/provider/azure_provider.py
@@ -1,0 +1,78 @@
+from azure.storage.blob import BlobServiceClient
+from azure.core.exceptions import AzureError, ResourceNotFoundError, HttpResponseError, ClientAuthenticationError
+
+from .base_provider import BaseProvider
+from ..common.exceptions import CloudConnectionError, CredentialsNotFoundError
+from ..common.logging import get_logger
+
+logger = get_logger()
+
+
+class AzureProvider(BaseProvider):
+    def __init__(self, bucket_name, bucket_path, region):
+        self.blob_service_client = None
+        self.bucket_name = bucket_name
+        self.region = region
+        partial_bucket_path = bucket_path[1:] if bucket_path.startswith('/') else bucket_path
+        self.bucket_path = partial_bucket_path + '/' if partial_bucket_path else partial_bucket_path
+
+    def setup_connection_to_bucket(self, **kwargs):
+        logger.info(f'Connecting to Azure bucket: {self.bucket_name}')
+
+        connection_string = kwargs.get('connection_string')
+        while not connection_string:
+            logger.info('  Please enter your connection string: [!i]')
+            connection_string = input().strip()
+
+        try:
+            self.blob_service_client = BlobServiceClient.from_connection_string(connection_string)
+            container_client = self.blob_service_client.get_container_client(self.bucket_name)
+            if not container_client.exists():  # pylint: disable=E1120
+                raise FileNotFoundError(f"Container '{self.bucket_name}' not found in Azure storage account.")
+            return self
+        except ClientAuthenticationError as exc:
+            raise CredentialsNotFoundError('There was credential error when trying to connect '
+                                           'to Azure storage account') from exc
+
+    def read_file(self, path: str) -> bytes:
+        try:
+            blob_client = self.blob_service_client.get_blob_client(container=self.bucket_name,
+                                                                   blob=f'{self.bucket_path}{path}')
+            return blob_client.download_blob().readall()
+        except ResourceNotFoundError as exc:
+            raise FileNotFoundError(exc) from exc
+        except HttpResponseError as exc:
+            if exc.status_code == 403:
+                raise PermissionError(
+                    f"Access denied to read file '{self.bucket_path}{path}' in container '{self.bucket_name}'.") from exc
+            else:
+                raise CloudConnectionError(
+                    f"An error occurred while reading file '{self.bucket_path}{path}': {exc}") from exc
+        except AzureError as exc:
+            raise ConnectionError(f"An error occurred while reading file '{self.bucket_path}{path}': {exc}") from exc
+
+    def write_file(self, path: str, data: bytes):
+        try:
+            blob_client = self.blob_service_client.get_blob_client(container=self.bucket_name,
+                                                                   blob=f'{self.bucket_path}{path}')
+            blob_client.upload_blob(data, overwrite=True)
+        except HttpResponseError as exc:
+            if exc.status_code == 403:
+                raise PermissionError(
+                    f"Access denied to write file '{path}' in container '{self.bucket_name}'.") from exc
+            else:
+                raise CloudConnectionError(f"An error occurred while writing file '{path}': {exc}") from exc
+        except AzureError as exc:
+            raise CloudConnectionError(f"An error occurred while writing file '{path}': {exc}") from exc
+
+    def list_files_in_path(self, path: str) -> list:
+        container_client = self.blob_service_client.get_container_client(self.bucket_name)
+        blob_list = container_client.list_blobs(name_starts_with=path)
+        file_paths = []
+        for blob in blob_list:
+            # Only add file names, not directories
+            if not blob.name.endswith('/'):
+                _, _, file_path = blob.name.partition('/data/v2/current/')
+                file_paths.append(file_path)
+
+        return file_paths

--- a/src/hdx_cli/library_api/provider/base_provider.py
+++ b/src/hdx_cli/library_api/provider/base_provider.py
@@ -1,0 +1,23 @@
+from abc import ABC, abstractmethod
+
+
+class BaseProvider(ABC):
+    @abstractmethod
+    def setup_connection_to_bucket(self, **kwargs):
+        """Set up the connection to the bucket."""
+        pass
+
+    @abstractmethod
+    def read_file(self, path: str) -> bytes:
+        """Reads bytes from files in the bucket."""
+        pass
+
+    @abstractmethod
+    def write_file(self, path: str, data: bytes):
+        """Writes bytes to a bucket."""
+        pass
+
+    @abstractmethod
+    def list_files_in_path(self, path: str) -> list:
+        """Return a list of files from a path."""
+        pass

--- a/src/hdx_cli/library_api/provider/gcp_provider.py
+++ b/src/hdx_cli/library_api/provider/gcp_provider.py
@@ -1,0 +1,83 @@
+from google.cloud.storage import Client
+from google.cloud.exceptions import NotFound, Forbidden, GoogleCloudError
+from google.auth.exceptions import DefaultCredentialsError
+from google.resumable_media.common import DataCorruption
+
+from .base_provider import BaseProvider
+from ..common.exceptions import CloudConnectionError, CredentialsNotFoundError
+from ..common.logging import get_logger
+
+logger = get_logger()
+
+CONTENT_TYPE = 'application/octet-stream'
+# Use a large timeout to write solves error like ->
+# ('Connection aborted.', TimeoutError('The write operation timed out'))
+LARGE_TIMEOUT = 1800
+
+
+def _retry_read_file(bucket, path):
+    """Retry the download for a blob."""
+    blob = bucket.blob(path)
+    return blob.download_as_bytes()
+
+
+class GcpProvider(BaseProvider):
+    def __init__(self, bucket_name, bucket_path, region):
+        self.client = None
+        self.bucket = None
+        self.bucket_name = bucket_name
+        self.region = region
+        partial_bucket_path = bucket_path[1:] if bucket_path.startswith('/') else bucket_path
+        self.bucket_path = partial_bucket_path + '/' if partial_bucket_path else partial_bucket_path
+
+    def setup_connection_to_bucket(self, **kwargs):
+        logger.info(f'Connecting to GCP bucket: {self.bucket_name}')
+
+        google_application_credentials = kwargs.get('google_application_credentials')
+        while not google_application_credentials:
+            logger.info('  Enter the Google credentials JSON file path: [!i]')
+            google_application_credentials = input().strip()
+
+        try:
+            self.client = Client.from_service_account_json(google_application_credentials)
+            self.bucket = self.client.get_bucket(self.bucket_name)
+            return self
+        except FileNotFoundError as exc:
+            raise CredentialsNotFoundError() from exc
+        except DefaultCredentialsError as exc:
+            raise CredentialsNotFoundError() from exc
+
+    def read_file(self, path: str) -> bytes:
+        try:
+            blob = self.bucket.blob(f'{self.bucket_path}{path}')
+            return blob.download_as_bytes()
+        except NotFound as exc:
+            raise FileNotFoundError(f"File '{path}' not found in '{self.bucket_name}' bucket.") from exc
+        except Forbidden as exc:
+            raise PermissionError(f"Access denied to read file '{path}' in '{self.bucket_name}' bucket.") from exc
+        except GoogleCloudError as exc:
+            raise CloudConnectionError(f"An error occurred while reading file '{path}': {exc}") from exc
+        except DataCorruption:
+            return _retry_read_file(self.bucket, f'{self.bucket_path}{path}')
+
+    def write_file(self, path: str, data: bytes):
+        try:
+            blob = self.bucket.blob(f'{self.bucket_path}{path}')
+            blob.upload_from_string(data, content_type=CONTENT_TYPE, timeout=LARGE_TIMEOUT)
+        except NotFound as exc:
+            raise FileNotFoundError(f"Destination '{path}' not found in bucket.") from exc
+        except Forbidden as exc:
+            raise PermissionError(f"Access denied to write file '{path}' in '{self.bucket_name}' bucket.") from exc
+        except GoogleCloudError as exc:
+            raise CloudConnectionError(f"An error occurred while writing file '{path}': {exc}") from exc
+
+    def list_files_in_path(self, path: str) -> list:
+        blobs = self.bucket.list_blobs(prefix=path)
+        file_paths = []
+        for blob in blobs:
+            # Only add file names, not directories
+            if not blob.name.endswith('/'):
+                _, _, file_path = blob.name.partition('/data/v2/current/')
+                file_paths.append(file_path)
+
+        return file_paths

--- a/src/hdx_cli/library_api/provider/linode_provider.py
+++ b/src/hdx_cli/library_api/provider/linode_provider.py
@@ -1,0 +1,85 @@
+import boto3
+from botocore.exceptions import NoCredentialsError, ClientError
+
+from .base_provider import BaseProvider
+from ..common.exceptions import CloudConnectionError, CredentialsNotFoundError
+from ..common.logging import get_logger
+
+logger = get_logger()
+
+
+LINODE_ENDPOINT_URL = 'linodeobjects.com'
+
+
+class LinodeProvider(BaseProvider):
+    def __init__(self, bucket_name, bucket_path, region):
+        self.s3_client = None
+        self.bucket_name = bucket_name
+        self.region = region
+        partial_bucket_path = bucket_path[1:] if bucket_path.startswith('/') else bucket_path
+        self.bucket_path = partial_bucket_path + '/' if partial_bucket_path else partial_bucket_path
+
+    def setup_connection_to_bucket(self, **kwargs):
+        logger.info(f'Connecting to Linode bucket: {self.bucket_name}')
+
+        linode_access_key_id = kwargs.get('linode_access_key_id')
+        linode_access_secret_id = kwargs.get('linode_access_secret_id')
+        while not linode_access_key_id or not linode_access_secret_id:
+            logger.info('  Please enter your access key ID: [!i]')
+            linode_access_key_id = input().strip()
+            logger.info('  Please enter your secret access ID: [!i]')
+            linode_access_secret_id = input().strip()
+
+        try:
+            bucket_url = f'https://{self.region}.{LINODE_ENDPOINT_URL}'
+            self.s3_client = boto3.client('s3',
+                                          aws_access_key_id=linode_access_key_id,
+                                          aws_secret_access_key=linode_access_secret_id,
+                                          endpoint_url=bucket_url)
+            self.s3_client.list_objects_v2(Bucket=self.bucket_name)
+            return self
+        except NoCredentialsError as exc:
+            raise CredentialsNotFoundError("AWS credentials not found. Please provide valid credentials.") from exc
+        except ClientError as exc:
+            error_code = exc.response['Error']['Code']
+            if error_code == 'AccessDenied':
+                raise PermissionError(
+                    f"Access denied to bucket '{self.bucket_name}'. Please check your permissions.") from exc
+            else:
+                raise CloudConnectionError(
+                    f"There was an error setting up connection to bucket '{self.bucket_name}': {exc}") from exc
+
+    def read_file(self, path: str) -> bytes:
+        try:
+            response = self.s3_client.get_object(Bucket=self.bucket_name, Key=f'{self.bucket_path}{path}')
+            return response['Body'].read()
+        except ClientError as exc:
+            error_code = exc.response['Error']['Code']
+            if error_code == 'NoSuchKey':
+                raise FileNotFoundError(f"File '{path}' not found in '{self.bucket_name}' bucket.") from exc
+            elif error_code == 'AccessDenied':
+                raise PermissionError(f"Access denied to read file '{path}' in '{self.bucket_name}' bucket.") from exc
+            else:
+                raise CloudConnectionError(f"There was an error reading file '{path}': {exc}") from exc
+        except NoCredentialsError as exc:
+            raise CredentialsNotFoundError() from exc
+
+    def write_file(self, path: str, data: bytes):
+        try:
+            self.s3_client.put_object(Bucket=self.bucket_name, Key=f'{self.bucket_path}{path}', Body=data)
+        except ClientError as exc:
+            raise CloudConnectionError(f"There was an error writing file '{path}': {exc}") from exc
+        except NoCredentialsError as exc:
+            raise CredentialsNotFoundError() from exc
+
+    def list_files_in_path(self, path: str) -> list:
+        response = self.s3_client.list_objects_v2(Bucket=self.bucket_name, Prefix=path)
+        file_paths = []
+        if 'Contents' in response:
+            for obj in response['Contents']:
+                # Only add file names, not directories
+                if not obj['Key'].endswith('/'):
+                    _, _, file_path = obj['Key'].partition('/data/v2/current/')
+                    file_paths.append(file_path)
+
+        return file_paths

--- a/src/hdx_cli/main.py
+++ b/src/hdx_cli/main.py
@@ -15,7 +15,8 @@ from hdx_cli.cli_interface.storage import commands as storage_
 from hdx_cli.cli_interface.profile import commands as profile_
 from hdx_cli.cli_interface.pool import commands as pool_
 from hdx_cli.cli_interface.sources import commands as sources_
-from hdx_cli.cli_interface.migrate import commands as migrate_
+# from hdx_cli.cli_interface.migrate import commands as migrate_
+from hdx_cli.cli_interface.migrate import commands_v2 as migrate_
 from hdx_cli.cli_interface.integration import commands as integration_
 from hdx_cli.cli_interface.user import commands as user_
 from hdx_cli.cli_interface.role import commands as role_
@@ -31,7 +32,7 @@ from hdx_cli.library_api.common.profile import save_profile, get_profile_data_fr
 from hdx_cli.library_api.common.auth_utils import load_user_context
 from hdx_cli.library_api.common.logging import set_debug_logger, set_info_logger, get_logger
 
-VERSION = "1.0-rc51"
+VERSION = "1.0-rc53"
 
 
 from hdx_cli.library_api.common.auth import (

--- a/src/hdx_cli/main.py
+++ b/src/hdx_cli/main.py
@@ -57,8 +57,8 @@ def _first_time_use_config(profile_config_file):
         return
     save_profile(profile_wizard_info.username,
                  profile_wizard_info.hostname,
-                 profile_config_file,
                  'default',
+                 profile_config_file=profile_config_file,
                  scheme=profile_wizard_info.scheme)
     logger.info('')
     logger.info(f'Your configuration with profile [default] has been created at {profile_config_file}')


### PR DESCRIPTION
The migrate command already existed in the CLI, but it now performs different functions. 
The updated migrate command allows for:

- Migrating projects, tables, transforms, and data to another cluster, including within the same cluster.
- Migrating only a subset of data by filtering with `min_timestamp` and `max_timestamp`.
- Performing a dry run migration between two clusters that share the buckets where the partitions are stored.
- Recovering a migration if an error occurs.