### PR TITLE
Reuse RClone remotes for migration process

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ maintainers = [
 
 [tool.poetry]
 name = "hdxcli"
-version = "1.0-rc67"
+version = "1.0-rc69"
 description = "Hydrolix command line utility to do CRUD operations on projects, tables, transforms and other resources in Hydrolix clusters"
 authors = ["German Diago Gomez <german@hydrolix.io>", "Agustin Actis <agustin@hydrolix.io>"]
 license = "MIT license"

--- a/src/hdx_cli/cli_interface/migrate/data.py
+++ b/src/hdx_cli/cli_interface/migrate/data.py
@@ -71,7 +71,7 @@ def migrate_partitions_threaded(migration_list: list,
 
     failed_items = Queue()
     total_items = len(migration_list)
-    max_failures = 1 # int(total_items * MAX_FAILURE_RATIO)
+    max_failures = int(total_items * MAX_FAILURE_RATIO)
     stop_migration = threading.Event()
 
     def sync_partition(from_to_path):

--- a/src/hdx_cli/cli_interface/migrate/data.py
+++ b/src/hdx_cli/cli_interface/migrate/data.py
@@ -22,7 +22,7 @@ from hdx_cli.library_api.common.exceptions import MigrationFailureException
 
 logger = get_logger()
 
-MAX_FAILURE_RATIO = 0.10
+MAX_FAILURE_RATIO = 0.15
 
 def summarize_migration_and_request_confirmation(source_profile: ProfileUserContext,
                                                  target_profile: ProfileUserContext,
@@ -61,6 +61,7 @@ def summarize_migration_and_request_confirmation(source_profile: ProfileUserCont
 def migrate_partitions_threaded(migration_list: list,
                                 migrated_sizes_queue: Queue,
                                 exceptions: Queue,
+                                migration_done: threading.Event,
                                 rc_config: RcloneAPIConfig,
                                 concurrency: int,
                                 remotes: dict
@@ -70,18 +71,17 @@ def migrate_partitions_threaded(migration_list: list,
 
     failed_items = Queue()
     total_items = len(migration_list)
-    max_failures = int(total_items * MAX_FAILURE_RATIO)
-
-    migration_done = threading.Event()
+    max_failures = 1 # int(total_items * MAX_FAILURE_RATIO)
+    stop_migration = threading.Event()
 
     def sync_partition(from_to_path):
-        if migration_done.is_set():
+        if stop_migration.is_set():
             return
 
         # If the migration process has failed more than 10% (MAX_FAILURE_RATIO) of the total items, stop the migration process
         failed_count_ = failed_items.qsize()
         if failed_count_ > max_failures:
-            migration_done.set()
+            stop_migration.set()
             exceptions.put(MigrationFailureException(
                     f"Number of failed migrations ({failed_count_}) exceeds "
                     f"the allowed maximum ({max_failures})."
@@ -93,17 +93,18 @@ def migrate_partitions_threaded(migration_list: list,
         response = post_with_retries(url, data, user=rc_config.user, password=rc_config.password)
         if not response or response.status_code != 200:
             failed_items.put(from_to_path)
+            logger.debug(f"Failed to migrate partition: {from_to_path}")
         else:
             migrated_sizes_queue.put(from_to_path[2])
 
     def sync_partition_retry(from_to_path):
-        if migration_done.is_set():
+        if stop_migration.is_set():
             return
 
         data = {"srcFs": from_to_path[0], "dstFs": from_to_path[1]}
         response = post_with_retries(url, data, user=rc_config.user, password=rc_config.password)
         if not response or response.status_code != 200:
-            migration_done.set()
+            stop_migration.set()
             exceptions.put(MigrationFailureException(
                 "Failed to migrate partition for the second time."
             ))
@@ -116,6 +117,7 @@ def migrate_partitions_threaded(migration_list: list,
 
     failed_count = failed_items.qsize()
     if failed_count == 0 or not exceptions.empty():
+        migration_done.set()
         return
 
     retry_failed_items = []
@@ -126,11 +128,13 @@ def migrate_partitions_threaded(migration_list: list,
     # It keeps the same remotes names but creates new connections
     recreate_remotes(remotes)
 
-    migration_done.clear()
+    stop_migration.clear()
     # Reduce the number of workers to avoid overloading the rclone API
     # In general, failed items are bigger than successful ones
     with ThreadPoolExecutor(max_workers=4) as executor:
         executor.map(sync_partition_retry, retry_failed_items)
+
+    migration_done.set()
 
 
 def get_migration_list(src_remote: RCloneRemote,
@@ -170,11 +174,20 @@ def migrate_partition_and_monitor(migration_list: list,
                                   partitions_size: int
                                   ) -> None:
     migrated_sizes_queue = Queue()
+    migration_done = threading.Event()
     threading.Thread(
         target=migrate_partitions_threaded,
-        args=(migration_list, migrated_sizes_queue, exceptions, rc_config, concurrency, remotes)
+        args=(
+            migration_list,
+            migrated_sizes_queue,
+            exceptions,
+            migration_done,
+            rc_config,
+            concurrency,
+            remotes
+        )
     ).start()
-    monitor_progress(partitions_size, migrated_sizes_queue, exceptions)
+    monitor_progress(partitions_size, migrated_sizes_queue, exceptions, migration_done)
 
 
 def upload_catalog_and_monitor(profile: ProfileUserContext,
@@ -186,6 +199,7 @@ def upload_catalog_and_monitor(profile: ProfileUserContext,
     partitions_count = catalog.get_partitions_count()
     uploaded_count = Queue()
     exceptions = Queue()
+    upload_done = threading.Event()
     threading.Thread(
         target=update_catalog_and_upload,
         args=(
@@ -193,6 +207,7 @@ def upload_catalog_and_monitor(profile: ProfileUserContext,
             catalog,
             uploaded_count,
             exceptions,
+            upload_done,
             target_data,
             target_storage_id,
             reuse_partitions
@@ -200,7 +215,9 @@ def upload_catalog_and_monitor(profile: ProfileUserContext,
     ).start()
     monitor_progress(
         partitions_count,
-        uploaded_count, exceptions,
+        uploaded_count,
+        exceptions,
+        upload_done,
         unit="units",
         unit_scale=False,
         unit_divisor=1,

--- a/src/hdx_cli/cli_interface/migrate/helpers.py
+++ b/src/hdx_cli/cli_interface/migrate/helpers.py
@@ -1,4 +1,5 @@
 import sys
+import threading
 import time
 from dataclasses import dataclass, field
 from queue import Queue
@@ -54,6 +55,7 @@ def update_catalog_and_upload(profile: ProfileUserContext,
                               catalog: Catalog,
                               uploaded_count: Queue,
                               exceptions: Queue,
+                              upload_done: threading.Event,
                               target_data: MigrationData,
                               target_storage_id: str,
                               reuse_partitions
@@ -67,6 +69,8 @@ def update_catalog_and_upload(profile: ProfileUserContext,
         catalog.upload(profile, uploaded_count)
     except Exception as exc:
         exceptions.put(exc)
+
+    upload_done.set()
 
 
 def bytes_to_human_readable(amount: int) -> str:
@@ -103,7 +107,6 @@ def print_summary(source_hostname: str,
     logger.info(f"- Target:")
     logger.info(f"    Hostname: {target_hostname}")
     logger.info(f"    Table: {target_table}")
-    logger.info("")
     logger.info(f"- Data:")
     logger.info(f"    Rows: {rows}")
     logger.info(f"    Partitions: {partitions}")
@@ -115,6 +118,7 @@ def print_summary(source_hostname: str,
 def monitor_progress(total_count: int,
                      migrated_queue: Queue,
                      exceptions_queue: Queue,
+                     event_done: threading.Event,
                      unit: str = "B",
                      unit_scale: bool = True,
                      unit_divisor: int = 1024,
@@ -138,9 +142,11 @@ def monitor_progress(total_count: int,
         else:
             time.sleep(0.5)
         if not exceptions_queue.empty():
-            progress_bar.set_description(desc="ERROR")
-            progress_bar.close()
-            return
+            progress_bar.set_description(desc="Error, finishing")
+            event_done.wait()
+            break
+            # progress_bar.close()
+            # return
     progress_bar.close()
 
 

--- a/src/hdx_cli/cli_interface/migrate/rc/rc_remotes.py
+++ b/src/hdx_cli/cli_interface/migrate/rc/rc_remotes.py
@@ -3,8 +3,6 @@ import os
 import random
 import string
 
-from hdx_cli.cli_interface.migrate.helpers import confirm_action
-from hdx_cli.cli_interface.migrate.rc.rc_manager import RcloneAPIConfig
 from hdx_cli.library_api.common.exceptions import (
     RCloneRemoteException,
     RCloneRemoteCheckException,
@@ -85,17 +83,33 @@ def _get_linode_config(remote):
     return config
 
 
-def _get_check_remote_body(remote):
-    bucket_path = remote.bucket_path if remote.bucket_path != "/" else ""
-    remote_dir = f"{remote.bucket_name}{bucket_path}"
+def get_check_remote_body(bucket_name: str, bucket_path: str, remote_name: str) -> dict:
+    bucket_path = bucket_path if bucket_path != "/" else ""
+    remote_dir = f"{bucket_name}{bucket_path}"
     return {
-        "fs": f"{remote.name}:",
+        "fs": f"{remote_name}:",
         "remote": remote_dir,
         "opt": {
             "recurse": False,
             "dirsOnly": True
         }
     }
+
+
+def get_remote_config(remote):
+    if remote.cloud == "azure":
+        return _get_azure_config()
+    elif remote.cloud == "gcp":
+        return _get_gcp_config(remote)
+    elif remote.cloud in ["aws", "linode"]:
+        if remote.endpoint or remote.cloud == "linode":
+            return _get_linode_config(remote)
+        return _get_aws_config(remote)
+    else:
+        raise ValueError(
+            "Unsupported cloud provider. Supported providers: azure, gcp, aws, linode."
+        )
+
 
 class RCloneRemote:
     def __init__(self):
@@ -108,48 +122,9 @@ class RCloneRemote:
         self.rc_config = None
         self.remote_config = None
 
-    def create_remote(self,
-                      rc_config: RcloneAPIConfig,
-                      storage_config: dict,
-                      bucket_side: str
-                      ) -> None:
-        self.cloud = storage_config.get("cloud")
-        self.bucket_name = storage_config.get("bucket_name")
-        bucket_path = storage_config.get("bucket_path", "/")
-        self.bucket_path = bucket_path if bucket_path.endswith("/") else f"{bucket_path}/"
-        self.region = storage_config.get("region", "")
-        self.endpoint = storage_config.get("endpoint", "")
-        self.rc_config = rc_config
-
-        max_retries = 3
-        attempt = 0
-        while attempt < max_retries:
-            self.name = f"{self.bucket_name}_{generate_random_string()}"
-            logger.info(f"Please, provide credentials for the {bucket_side.upper()} bucket:")
-            logger.info(f"  Name:   {self.bucket_name}")
-            logger.info(f"  Path:   {self.bucket_path}")
-            logger.info(f"  Cloud:  {self.cloud}")
-            logger.info(f"  Region: {self.region}")
-
-            try:
-                self.remote_config = self._get_remote_config()
-                self.remote_config["name"] = self.name
-                self._send_create_request()
-                self._check_remote_exists()
-                logger.info("Bucket connection successfully created")
-                logger.info("")
-                break
-            except RCloneRemoteException as e:
-                logger.debug(f"Attempt {attempt + 1} failed with exception: {e}")
-
-                attempt += 1
-                if attempt < max_retries:
-                    logger.info("There was an error during the bucket connection.")
-                    if confirm_action("Would you like to retry?"):
-                        logger.info("")
-                        continue
-                logger.debug("Connection failed.")
-                raise e
+    def create_remote(self) -> None:
+        self._send_create_request()
+        self.check_remote_exists()
 
     def _send_create_request(self) -> None:
         base_url = self.rc_config.get_url()
@@ -163,33 +138,19 @@ class RCloneRemote:
         if not response or response.status_code != 200:
             raise RCloneRemoteCreationException(self.bucket_name, self.cloud)
 
-    def _check_remote_exists(self) -> None:
-        data = _get_check_remote_body(self)
+    def check_remote_exists(self, payload=None) -> None:
+        if not payload:
+            payload = get_check_remote_body(self.bucket_name, self.bucket_path, self.name)
         base_url = self.rc_config.get_url()
         response = post_with_retries(
             f"{base_url}/operations/list",
-            data,
+            payload,
             user=self.rc_config.user,
             password=self.rc_config.password
         )
 
         if not response or response.status_code != 200:
-            self.close_remote()
             raise RCloneRemoteCheckException(self.bucket_name, self.cloud)
-
-    def _get_remote_config(self):
-        if self.cloud == "azure":
-            return _get_azure_config()
-        elif self.cloud == "gcp":
-            return _get_gcp_config(self)
-        elif self.cloud in ["aws", "linode"]:
-            if self.endpoint or self.cloud == "linode":
-                return _get_linode_config(self)
-            return _get_aws_config(self)
-        else:
-            raise ValueError(
-                "Unsupported cloud provider. Supported providers: azure, gcp, aws, linode."
-            )
 
     def close_remote(self) -> None:
         data = {"name": self.name}
@@ -209,4 +170,4 @@ class RCloneRemote:
     def recreate_remote(self) -> None:
         self.close_remote()
         self._send_create_request()
-        self._check_remote_exists()
+        self.check_remote_exists()

--- a/src/hdx_cli/cli_interface/migrate/rc/rc_utils.py
+++ b/src/hdx_cli/cli_interface/migrate/rc/rc_utils.py
@@ -1,14 +1,108 @@
+import random
+import string
+from copy import deepcopy
+from typing import Tuple, Optional
+
+from hdx_cli.cli_interface.migrate.helpers import confirm_action
 from hdx_cli.cli_interface.migrate.rc.rc_manager import RcloneAPIConfig
-from hdx_cli.cli_interface.migrate.rc.rc_remotes import RCloneRemote
-from hdx_cli.library_api.common.exceptions import StorageNotFoundError
+from hdx_cli.cli_interface.migrate.rc.rc_remotes import (
+    RCloneRemote,
+    get_remote_config,
+    get_check_remote_body
+)
+from hdx_cli.library_api.common.exceptions import (
+    StorageNotFoundError,
+    RCloneRemoteException,
+    RCloneRemoteCheckException
+)
 from hdx_cli.library_api.common.storage import get_storage_by_id
+from hdx_cli.library_api.common.logging import get_logger
+
+logger = get_logger()
+
+
+def generate_random_string(length=5):
+    return ''.join(random.choices(string.ascii_lowercase + string.digits, k=length))
+
+
+def create_remote(storage_settings: dict,
+                  remotes: dict,
+                  rc_config: RcloneAPIConfig,
+                  migration_side: str,
+                  ) -> RCloneRemote:
+    cloud = storage_settings.get("cloud")
+    bucket_name = storage_settings.get("bucket_name")
+    bucket_path = storage_settings.get("bucket_path", "/")
+    bucket_path = bucket_path if bucket_path.endswith("/") else f"{bucket_path}/"
+    region = storage_settings.get("region", "")
+    endpoint = storage_settings.get("endpoint", "")
+
+    logger.info(f"Please, provide credentials for the {migration_side.upper()} bucket:")
+    logger.info(f"  Name:     {bucket_name}")
+    logger.info(f"  Path:     {bucket_path}")
+    logger.info(f"  Cloud:    {cloud}")
+    logger.info(f"  Region:   {region}")
+    logger.info(f"  Endpoint: {endpoint}")
+
+    new_remote, reused_remote = check_remotes_stock(
+        remotes,
+        bucket_name,
+        bucket_path,
+        cloud,
+        region
+    )
+    if new_remote and reused_remote:
+        logger.info(f"Access granted using a previous connection")
+        logger.info(f"for bucket name: {reused_remote.bucket_name}{reused_remote.bucket_path}")
+        logger.info("Reusing this connection may improve transfer speed.")
+        logger.info("If you choose not to reuse it, credentials will be requested.")
+        logger.info("")
+
+        if confirm_action("Confirm reuse of this connection?"):
+            logger.debug(f"Remote '{reused_remote.name}' is being reused for bucket: {storage_settings}")
+            logger.info("")
+            return new_remote
+
+    max_retries = 3
+    attempt = 0
+    while attempt < max_retries:
+        new_remote = RCloneRemote()
+        new_remote.bucket_name = bucket_name
+        new_remote.bucket_path = bucket_path
+        new_remote.cloud = cloud
+        new_remote.region = region
+        new_remote.endpoint = endpoint
+        new_remote.rc_config = rc_config
+        new_remote.name = f"{bucket_name}_{generate_random_string()}"
+
+        try:
+            new_remote.remote_config = get_remote_config(new_remote)
+            new_remote.remote_config["name"] = new_remote.name
+            new_remote.create_remote()
+
+            logger.info("Bucket connection successfully created")
+            logger.info("")
+            return new_remote
+        except RCloneRemoteException as exc:
+            logger.debug(f"Attempt {attempt + 1} failed with exception: {exc}")
+            if isinstance(exc, RCloneRemoteCheckException):
+                new_remote.close_remote()
+
+            attempt += 1
+            if attempt < max_retries:
+                logger.info("There was an error during the bucket connection.")
+                if confirm_action("Would you like to retry?"):
+                    logger.info("")
+                    continue
+            logger.debug("Connection failed.")
+            raise exc
 
 
 def get_remote(remotes: dict,
 			   storages: list,
 			   storage_id: str,
 			   rc_config: RcloneAPIConfig,
-               bucket_side: str = ""
+               migration_side: str = ""
 			   ) -> RCloneRemote:
     if remote := remotes.get(storage_id):
         return remote
@@ -18,8 +112,7 @@ def get_remote(remotes: dict,
     if not storage_settings:
         raise StorageNotFoundError(f"Storage UUID ({storage_id}) not found.")
 
-    remote = RCloneRemote()
-    remote.create_remote(rc_config, storage_settings, bucket_side)
+    remote = create_remote(storage_settings, remotes, rc_config, migration_side)
     remotes[storage_id] = remote
     return remote
 
@@ -32,3 +125,31 @@ def close_remotes(remotes: dict) -> None:
 def recreate_remotes(remotes: dict) -> None:
     for remote in remotes.values():
         remote.recreate_remote()
+
+
+def check_existing_remote(remote: RCloneRemote, bucket_name, bucket_path) -> bool:
+    bucket_info = get_check_remote_body(bucket_name, bucket_path, remote.name)
+    try:
+        remote.check_remote_exists(payload=bucket_info)
+        return True
+    except RCloneRemoteCheckException:
+        return False
+
+
+def check_remotes_stock(remotes: dict,
+                        bucket_name: str,
+                        bucket_path: str,
+                        cloud: str,
+                        region: str
+                        ) -> Tuple[Optional[RCloneRemote], Optional[RCloneRemote]]:
+    for remote in remotes.values():
+        assert isinstance(remote, RCloneRemote)
+        if cloud != remote.cloud or region != remote.region:
+            continue
+
+        if check_existing_remote(remote, bucket_name, bucket_path):
+            new_remote = deepcopy(remote)
+            new_remote.bucket_name = bucket_name
+            new_remote.bucket_path = bucket_path
+            return new_remote, remote
+    return None, None

--- a/src/hdx_cli/main.py
+++ b/src/hdx_cli/main.py
@@ -28,7 +28,7 @@ from hdx_cli.library_api.common.first_use import is_first_time_use, first_time_u
 from hdx_cli.library_api.common.logging import set_debug_logger, set_info_logger, get_logger
 from hdx_cli.cli_interface.set import commands as set_commands
 
-VERSION = "1.0-rc67"
+VERSION = "1.0-rc69"
 
 logger = get_logger()
 


### PR DESCRIPTION
When the migration failure limit is reached, the migration process stops. Previously, an error occurred because the main process did not wait for all threads to complete before ending. This PR fixes that issue by ensuring the main process waits for all threads to finish.

Additionally, this update reuses RClone remote connections, which helps reduce errors and increase transfer speed.