### PR TITLE
Enhance resource migration commands to include dependencies and child resources

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -10,7 +10,7 @@ jobs:
         with:
           python-version: '3.10'
       - name: "Install poetry"
-        run: python3 -m pip install poetry
+        run: python3 -m pip install poetry==1.8.4
       - name: "Install hdxcli dependencies"
         run: python3 -m poetry install
       - name: "Set environment for tests"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ maintainers = [
 
 [tool.poetry]
 name = "hdxcli"
-version = "1.0-rc69"
+version = "1.0-rc71"
 description = "Hydrolix command line utility to do CRUD operations on projects, tables, transforms and other resources in Hydrolix clusters"
 authors = ["German Diago Gomez <german@hydrolix.io>", "Agustin Actis <agustin@hydrolix.io>"]
 license = "MIT license"

--- a/src/hdx_cli/cli_interface/common/migration/logs.py
+++ b/src/hdx_cli/cli_interface/common/migration/logs.py
@@ -1,0 +1,85 @@
+from enum import Enum, auto
+from typing import Union
+
+from .migration_rollback import (
+    MigrateStatus,
+    MigrationRollbackManager,
+    ResourceKind,
+    MigrationEntry
+)
+from ....library_api.common.logging import get_logger
+
+logger = get_logger()
+
+
+class LogType(Enum):
+    INFO = auto()
+    SUCCESS = auto()
+    WARNING = auto()
+    PROMPT = auto()
+
+
+def log_message(log_type: LogType, message: str, indent: int = 2):
+    """
+    Prints a message with a specified log type and indentation.
+
+    :param log_type: An enum value (INFO, SUCCESS, WARNING, PROMPT, etc.)
+    :param message: The text to display.
+    :param indent: Number of spaces to indent the message.
+    """
+    log_type_label = {
+        LogType.INFO:    "INFO",
+        LogType.SUCCESS: "SUCCESS",
+        LogType.WARNING: "WARNING",
+        LogType.PROMPT:  "PROMPT"
+    }.get(log_type, "INFO")
+
+    indent_spaces = " " * indent
+    logger.info(f"{indent_spaces}[{log_type_label}] {message}")
+
+
+def log_without_type(messages: Union[str, list[str]], indent: int = 2, sub_indent: int = 4):
+    """
+    Prints one or more lines without a log type label, applying consistent indentation.
+
+    :param messages:   A string or list of strings to display.
+    :param indent:     Number of spaces to indent before the 'sub_indent' is applied.
+    :param sub_indent: Additional indentation for each line.
+    """
+    base_spaces = " " * (indent + sub_indent)
+
+    if isinstance(messages, list):
+        for msg in messages:
+            logger.info(f"{base_spaces}{msg}")
+    else:
+        logger.info(f"{base_spaces}{messages}")
+
+
+def log_migration_status(
+        resource_type: str,
+        resource_name: str,
+        status: MigrateStatus,
+        rollback_manager: MigrationRollbackManager,
+        resource_kind: ResourceKind,
+        parents: list[str] = None
+):
+    """
+    Logs the migration status of a resource.
+
+    Args:
+        resource_type (str): The type of resource being migrated.
+        resource_name (str): The name of the resource.
+        status (MigrateStatus): The status of the migration.
+        rollback_manager (MigrationRollbackManager): The rollback manager instance.
+        resource_kind (ResourceKind): The kind of the resource.
+        parents (list[str]): The list of parent resources, if any.
+    """
+    result = "None"
+    if status == MigrateStatus.CREATED:
+        result = "Migrated"
+        m_entry = MigrationEntry(resource_name, resource_kind, parents)
+        rollback_manager.push_entry(m_entry)
+    elif status == MigrateStatus.SKIPPED:
+        result = "Skipped (was found)"
+    message = f"{resource_type} '{resource_name}' {result}"
+    log_message(LogType.SUCCESS, message, indent=0)

--- a/src/hdx_cli/cli_interface/common/migration/migration_rollback.py
+++ b/src/hdx_cli/cli_interface/common/migration/migration_rollback.py
@@ -4,10 +4,10 @@ from typing import List
 from urllib.parse import urlparse
 
 
-from ..common.undecorated_click_commands import basic_delete
-from ...library_api.common.logging import get_logger
-from ...library_api.common.generic_resource import access_resource_detailed
-from ...library_api.common.context import ProfileUserContext
+from ...common.undecorated_click_commands import basic_delete
+from ....library_api.common.logging import get_logger
+from ....library_api.common.generic_resource import access_resource_detailed
+from ....library_api.common.context import ProfileUserContext
 
 logger = get_logger()
 

--- a/src/hdx_cli/cli_interface/common/migration/resource_adapters.py
+++ b/src/hdx_cli/cli_interface/common/migration/resource_adapters.py
@@ -1,0 +1,371 @@
+import re
+
+from .logs import log_message, LogType, log_without_type
+from ....library_api.common.logging import get_logger
+
+logger = get_logger()
+
+
+def prompt_user_for_value(key: str, message=None, default=None):
+    if not message:
+        default_message = f" (default: {default})" if default else ""
+        prompt_message = f"Please, provide a value for '{key}'{default_message}"
+    else:
+        prompt_message = message
+    prompt_message = f"{prompt_message}: [!i]"
+
+    log_without_type(prompt_message)
+    user_input = input().strip()
+    return user_input if user_input else default
+
+
+def normalize_project(project: dict, reuse_partitions: bool = False) -> dict:
+    if not reuse_partitions:
+        project.pop("uuid", None)
+
+    return project
+
+
+def normalize_table(table: dict, reuse_partitions: bool = False) -> dict:
+    table_name = table.get("name")
+    if not reuse_partitions:
+        table.pop("uuid", None)
+    table_settings = table.get("settings", {})
+
+    # Summary
+    if table.get("type") == "summary":
+        summary_settings = table_settings.get("summary", {})
+        table_settings["summary"] = _update_parent_in_summary_sql(table_name, summary_settings)
+
+    # Autoingest
+    autoingest = table_settings.get("autoingest")
+    filtered_autoingest = []
+    if autoingest and isinstance(autoingest, list):
+        for element in autoingest:
+            if isinstance(element, dict) and element.get("enabled"):
+                updated_element = _adapt_table_autoingest(table_name, element)
+                if updated_element:
+                    filtered_autoingest.append(updated_element)
+    if filtered_autoingest:
+        table_settings["autoingest"] = filtered_autoingest
+    else:
+        table_settings.pop("autoingest", None)
+
+    # Merge pools
+    merge = table_settings.get("merge")
+    if merge and isinstance(merge, dict) and (pools := merge.get("pools")):
+        updated_pools = _adapt_table_merge_pools(table_name, pools)
+        if updated_pools:
+            merge["pools"] = updated_pools
+        else:
+            merge.pop("pools", None)
+
+    # Storage settings
+    storage_map = table_settings.get("storage_map", {})
+    if storage_map and storage_map.get("default_storage_id"):
+        updated_storage_map = _adapt_table_storage_map(table_name, storage_map)
+        if updated_storage_map:
+            table_settings["storage_map"] = updated_storage_map
+        else:
+            table_settings.pop("storage_map", None)
+
+    return table
+
+
+def _update_parent_in_summary_sql(table_name: str, summary_settings: dict) -> dict:
+    sql = summary_settings.get("sql")
+    summary_sql = summary_settings.get("summary_sql")
+    if not sql:
+        log_message(LogType.WARNING, "No SQL was found in the summary settings.")
+        log_message(LogType.PROMPT, "Please provide a valid SQL statement for the summary table")
+        sql = get_user_value_input("sql", "string")
+        logger.info("")
+
+    log_message(LogType.WARNING, f"Summary settings found in the table '{table_name}'")
+    current_project, current_table = _extract_table_name_from_sql(sql)
+    current_summary_parents = (
+        "Not Found"
+        if not current_project or not current_table
+        else f"{current_project}.{current_table}"
+    )
+    log_without_type(f"The current parents for the summary table are: {current_summary_parents}")
+    logger.info("")
+
+    log_message(
+        LogType.PROMPT,
+        "Please enter a new project and table in 'project.table' format "
+        "(leave blank to keep current)"
+    )
+    attempts = 3
+    while attempts > 0:
+        log_without_type("New parents 'project.table': [!i]")
+        new_project_table = input().strip()
+
+        if not new_project_table and current_project and current_table:
+            new_project, new_table = current_project, current_table
+            break
+
+        try:
+            new_project, new_table = new_project_table.split(".")
+            if new_project and new_table:
+                break
+            log_without_type("Invalid input. Ensure 'project.table' format is used")
+        except ValueError:
+            log_without_type("Invalid format. Please enter 'project.table' with a single dot")
+            attempts -= 1
+
+    if attempts == 0:
+        log_without_type("Maximum attempts reached. Keeping current project.table")
+        new_project, new_table = current_project, current_table
+
+    summary_settings["sql"] = sql.replace(
+        current_project, new_project
+    ).replace(
+        current_table, new_table
+    )
+    if summary_sql:
+        summary_settings["summary_sql"] = summary_sql.replace(
+            current_project, new_project
+        ).replace(
+            current_table, new_table
+        )
+
+    logger.info("")
+    return summary_settings
+
+
+def _extract_table_name_from_sql(sql):
+    pattern = r"(?i)\bFROM\s+([`\"']?\w+[`\"']?\.\w+)"
+    match = re.search(pattern, sql)
+    if not match:
+        return None, None
+
+    table_name = match.group(1).replace('`', '').replace('"', '').replace("'", "")
+    project, table = table_name.split(".")
+    return project, table
+
+
+def _adapt_table_storage_map(table_name:str, storage_map: dict) -> dict | None:
+    default_storage_id = storage_map.get("default_storage_id")
+    column_name = storage_map.get("column_name", "-")
+    column_value_mapping = storage_map.get("column_value_mapping", "-")
+
+    log_message(LogType.WARNING, f"Storage settings found in the table '{table_name}'")
+    log_without_type([f"Default Storage ID: {default_storage_id}",
+                      f"Column Name: {column_name}",
+                      f"Column Value Mapping: {column_value_mapping}",
+                      ""])
+    log_message(LogType.PROMPT, f"How would you like to proceed?")
+    log_without_type(["1) Preserve all existing settings without any changes",
+                      "2) Specify a new default storage ID",
+                      "3) Remove the storage settings (use cluster default)"])
+
+    user_input = 4
+    while user_input not in ["1", "2", "3"]:
+        log_without_type("Please enter your choice (1/2/3): [!i]")
+        user_input = input().strip().lower()
+
+    if user_input == "1":
+        logger.debug("Preserving the existing storage settings.")
+    elif user_input == "2":
+        new_default_storage_id = prompt_user_for_value(
+            "default_storage_id",
+            message="Please enter the new default storage ID",
+            default=default_storage_id
+        )
+        storage_map = {"default_storage_id": new_default_storage_id}
+    elif user_input == "3":
+        storage_map = None
+
+    logger.info("")
+    return storage_map
+
+
+def _adapt_table_merge_pools(table_name: str, pools: dict) -> dict | None:
+    log_message(LogType.WARNING, f"Merge pools settings found in the table '{table_name}'")
+    for key, value in pools.items():
+        log_without_type(f"{key}: {value}")
+    logger.info("")
+
+    log_message(LogType.PROMPT, f"How would you like to proceed?")
+    log_without_type(["1) Preserve all existing settings without any changes",
+                      "2) Specify a new merge pools settings",
+                      "3) Remove the merge pools settings"])
+    user_input = 4
+    while user_input not in ["1", "2", "3"]:
+        log_without_type("Please enter your choice (1/2/3): [!i]")
+        user_input = input().strip().lower()
+
+    updated_pools = {}
+    if user_input == "1":
+        logger.debug("Preserving the existing merge pools settings.")
+        updated_pools = pools
+    elif user_input == "2":
+        for key in pools.keys():
+            new_value = prompt_user_for_value(key)
+            if new_value:
+                updated_pools[key] = new_value
+    elif user_input == "3":
+        updated_pools = None
+
+    logger.info("")
+    return updated_pools
+
+
+def _adapt_table_autoingest(table_name:str, autoingest: dict) -> dict | None:
+    log_message(LogType.WARNING, f"Autoingest settings found in the table '{table_name}'")
+    for key, value in autoingest.items():
+        log_without_type(f"{key}: {value}")
+
+    log_message(LogType.PROMPT, f"How would you like to proceed?")
+    log_without_type(["1) Preserve all existing settings without any changes",
+                      "2) Specify a new autoingest settings",
+                      "3) Remove the autoingest settings"])
+
+    user_input = 4
+    while user_input not in ["1", "2", "3"]:
+        log_without_type("Please enter your choice (1/2/3): [!i]")
+        user_input = input().strip().lower()
+
+    updated_autoingest = {}
+    if user_input == "1":
+        logger.debug("Preserving the existing autoingest settings.")
+        updated_autoingest = autoingest
+    elif user_input == "2":
+        for key in ["transform", "source_credential_id", "bucket_credential_id"]:
+            new_value = prompt_user_for_value(key)
+            if new_value:
+                updated_autoingest[key] = new_value
+    elif user_input == "3":
+        updated_autoingest = None
+
+    logger.info("")
+    return updated_autoingest
+
+
+def normalize_transform(transform: dict) -> dict:
+    # Always remove the UUID
+    transform.pop("uuid", None)
+
+    # If sample_data is a list, normalize it to a single json or csv format
+    settings = transform.get("settings", {})
+    sample_data = settings.get("sample_data", None)
+    if isinstance(sample_data, list) and len(sample_data) == 1:
+        settings["sample_data"] = sample_data[0]
+
+    return transform
+
+
+def normalize_function(function: dict) -> dict:
+    # Always remove the UUID
+    function.pop("uuid", None)
+    return function
+
+
+def normalize_dictionary(dictionary: dict) -> dict:
+    # Always remove the UUID
+    dictionary.pop("uuid", None)
+    return dictionary
+
+
+def get_user_value_input(field_name: str, field_type: str):
+    while True:
+        user_input = prompt_user_for_value(
+            field_name,
+            message=f"* {field_name} ({field_type})"
+        )
+
+        if not user_input:
+            log_without_type(f"Invalid value. Please, try again")
+            continue
+
+        if "integer" in field_type:
+            try:
+                return int(user_input)
+            except ValueError or TypeError:
+                log_without_type("Invalid integer. Please enter a valid number")
+        elif "list" in field_type:
+            return [item.strip() for item in user_input.split(",") if item.strip()]
+        elif "boolean" in field_type:
+            if user_input.lower() in ('1', 'true', 't', 'yes', 'y'):
+                return True
+            elif user_input.lower() in ('0', 'false', 'f', 'no', 'n'):
+                return False
+            else:
+                log_without_type("Invalid value. Please enter 'true' or 'false'")
+        elif "decimal" in field_type:
+            try:
+                return float(user_input)
+            except ValueError or TypeError:
+                log_without_type("Invalid value. Please enter a valid decimal number")
+        else:
+            return user_input
+
+
+# def _adapt_resource_to_api_structure(
+#         resource_structure: dict,
+#         resource_settings: dict | None,
+#         parent_path="",
+#         first_time_input=True
+# ) -> dict:
+#     def is_empty(value):
+#         return value in (None, {}, [], "")
+#
+#     adapted_resource_settings = {}
+#     for field_name, field_props in resource_structure.items():
+#         if field_props.get("read_only", False):
+#             continue
+#
+#         is_required = field_props.get("required", False)
+#         field_type = field_props.get("type", "")
+#         resource_settings_value = resource_settings.get(field_name) if resource_settings else None
+#
+#         current_path = f"{parent_path}.{field_name}" if parent_path else field_name
+#
+#         if field_type == "nested object":
+#             children_structure = field_props.get("children", {})
+#             child_structure = field_props.get("child", None)
+#
+#             if children_structure:
+#                 if not resource_settings_value and not is_required:
+#                     continue
+#                 nested_dict, first_time_input = _adapt_resource_to_api_structure(
+#                     children_structure,
+#                     resource_settings_value or {},
+#                     parent_path=current_path,
+#                     first_time_input=first_time_input
+#                 )
+#                 if nested_dict or is_required:
+#                     adapted_resource_settings[field_name] = nested_dict
+#
+#             elif child_structure:
+#                 if resource_settings_value and isinstance(resource_settings_value, dict):
+#                     adapted_resource_settings[field_name] = {}
+#                     for key, value in resource_settings_value.items():
+#                         adapted_resource_settings[field_name][key] = value
+#
+#         else:
+#             if resource_settings_value is not None and not is_empty(resource_settings_value):
+#                 adapted_resource_settings[field_name] = resource_settings_value
+#             elif is_required:
+#                 logger.debug(f"Field '{current_path}', type '{field_type}' is required.")
+#                 log_message(LogType.WARNING, "The following fields are required to proceed:")
+#                 new_value = get_user_value_input(current_path, field_type)
+#                 adapted_resource_settings[field_name] = new_value
+#             else:
+#                 logger.debug(f"Field '{current_path}' was omitted because it is empty or None.")
+#
+#     return adapted_resource_settings
+#
+#
+# def adapt_resource_to_api_structure(
+#         profile: ProfileUserContext,
+#         resource_url: str,
+#         resource_settings: dict
+# ) -> dict:
+#     resource_structure = get_resource_settings_structure(profile, resource_url)
+#     if not resource_structure:
+#         return resource_settings
+#
+#     adapted_resource = _adapt_resource_to_api_structure(resource_structure, resource_settings)
+#     return adapted_resource

--- a/src/hdx_cli/cli_interface/common/migration/resource_migrations.py
+++ b/src/hdx_cli/cli_interface/common/migration/resource_migrations.py
@@ -3,21 +3,27 @@ import json
 
 from urllib.parse import urlparse
 
+from .logs import log_message, LogType, log_migration_status
+from .resource_adapters import (
+    normalize_project,
+    normalize_transform,
+    normalize_table,
+    normalize_dictionary,
+    normalize_function
+)
 from .migration_rollback import (
     MigrationRollbackManager,
     DoNothingMigrationRollbackManager,
-    MigrationEntry,
     ResourceKind,
     MigrateStatus
 )
-from ..common.undecorated_click_commands import basic_create_from_dict_body, basic_show
-from ...library_api.common.auth_utils import get_profile
-from ...library_api.common.context import ProfileUserContext
-from ...library_api.common.exceptions import HttpException, HdxCliException
-from ...library_api.common import rest_operations as lro
-from ...library_api.common.generic_resource import access_resource_detailed
-from ...library_api.common.logging import get_logger
-
+from ...common.undecorated_click_commands import basic_create_from_dict_body, basic_show
+from ....library_api.common.auth_utils import get_profile
+from ....library_api.common.context import ProfileUserContext
+from ....library_api.common.exceptions import HttpException, HdxCliException
+from ....library_api.common import rest_operations as lro
+from ....library_api.common.generic_resource import access_resource_detailed
+from ....library_api.common.logging import get_logger
 
 logger = get_logger()
 
@@ -93,34 +99,6 @@ def migrate_resource_config(
         )
 
 
-def log_migration_status(
-        resource_type: str,
-        resource_name: str,
-        status: MigrateStatus,
-        rollback_manager: MigrationRollbackManager,
-        resource_kind: ResourceKind,
-        parents: list[str] = None
-):
-    """
-    Logs the migration status of a resource.
-
-    Args:
-        resource_type (str): The type of resource being migrated.
-        resource_name (str): The name of the resource.
-        status (MigrateStatus): The status of the migration.
-        rollback_manager (MigrationRollbackManager): The rollback manager instance.
-        resource_kind (ResourceKind): The kind of the resource.
-        parents (list[str]): The list of parent resources, if any.
-    """
-    logger.info(f"{resource_type} {resource_name}: [!n]")
-    if status == MigrateStatus.CREATED:
-        logger.info("Created Successfully")
-        m_entry = MigrationEntry(resource_name, resource_kind, parents)
-        rollback_manager.push_entry(m_entry)
-    elif status == MigrateStatus.SKIPPED:
-        logger.info("Skipped (was found)")
-
-
 def migrate_projects(
         source_profile: ProfileUserContext,
         target_profile: ProfileUserContext,
@@ -184,19 +162,20 @@ def migrate_project(
         source_project: str,
         target_project: str
 ):
+    """Migrates a single project."""
+    log_message(LogType.INFO, f"Migrating project '{target_project}'...", indent=0)
+    project_settings = json.loads(basic_show(source_profile, source_projects_path, source_project))
     try:
-        project_settings = json.loads(basic_show(source_profile, source_projects_path, source_project))
-        try:
-            del project_settings["uuid"]
-        except KeyError:
-            pass
-
         project_settings["name"] = target_project
+        project_settings = normalize_project(project_settings)
+
         basic_create_from_dict_body(target_profile, target_projects_path, project_settings)
     except HttpException as exc:
-        if exc.error_code != 400:
-            logger.debug(f"Error creating project: {exc}")
-            raise
+        if exc.error_code != 400 or "already exists" not in str(exc.message):
+            logger.debug(f"Error migrating project: {exc}")
+            raise exc
+
+        logger.debug(f"Project already exists: {exc}")
         return target_project, MigrateStatus.SKIPPED
     else:
         return target_project, MigrateStatus.CREATED
@@ -314,20 +293,19 @@ def migrate_table(
         target_table: str
 ):
     """Migrates a single table."""
+    log_message(LogType.INFO, f"Migrating table '{target_table}'...", indent=0)
     table_settings = json.loads(basic_show(source_profile, source_tables_path, source_table))
     try:
-        try:
-            del table_settings["uuid"]
-            del table_settings["settings"]["autoingest"][0]["source"]
-        except KeyError:
-            pass
-
         table_settings["name"] = target_table
+        table_settings = normalize_table(table_settings)
+
         basic_create_from_dict_body(target_profile, target_tables_path, table_settings)
     except HttpException as exc:
-        if exc.error_code != 400:
-            logger.debug(f"Error creating table: {exc}")
+        if exc.error_code != 400 or "already exists" not in str(exc.message):
+            logger.debug(f"Error migrating table: {exc}")
             raise
+
+        logger.debug(f"Table already exists: {exc}")
         return target_table, MigrateStatus.SKIPPED
     else:
         return target_table, MigrateStatus.CREATED
@@ -410,21 +388,21 @@ def migrate_transform(
         target_transform: str
 ):
     """Migrates a single transform."""
+    log_message(LogType.INFO, f"Migrating transform '{target_transform}'...", indent=0)
     transform_settings = json.loads(
         basic_show(source_profile, source_transforms_path, source_transform)
     )
     try:
-        try:
-            del transform_settings["uuid"]
-        except KeyError:
-            pass
-
         transform_settings["name"] = target_transform
+        transform_settings = normalize_transform(transform_settings)
+
         basic_create_from_dict_body(target_profile, target_transforms_path, transform_settings)
     except HttpException as exc:
-        if exc.error_code != 400:
-            logger.debug(f"Error creating transform: {exc}")
-            raise
+        if exc.error_code != 400 or "already exists" not in str(exc.message):
+            logger.debug(f"Error migrating transform: {exc}")
+            raise exc
+
+        logger.debug(f"Transform already exists: {exc}")
         return target_transform, MigrateStatus.SKIPPED
     else:
         return target_transform, MigrateStatus.CREATED
@@ -503,6 +481,7 @@ def migrate_dictionary(
         target_dict: str
 ):
     """Migrates a single dictionary."""
+    log_message(LogType.INFO, f"Migrating dictionary '{target_dict}'...", indent=0)
     dictionary = json.loads(basic_show(source_profile, source_dicts_path, source_dict))
 
     d_settings = dictionary["settings"]
@@ -530,22 +509,21 @@ def migrate_dictionary(
         )
     except HttpException as exc:
         if exc.error_code != 400:
-            logger.debug(f"Error creating dictionary file for project: {exc}")
+            logger.debug(f"Error migrating dictionary file for project: {exc}")
             raise
         logger.debug(f"Dictionary file {d_file} already exists ({exc}). Skipping.")
     finally:
         try:
             dictionary["name"] = target_dict
-            try:
-                del dictionary["uuid"]
-            except KeyError:
-                pass
+            dictionary = normalize_dictionary(dictionary)
+
             basic_create_from_dict_body(target_profile, target_dicts_path, dictionary)
         except HttpException as exc:
-            if exc.error_code != 400:
-                logger.debug(f"Error creating dictionary for project: {exc}")
-                raise
-            logger.debug(f"Dictionary {target_dict} already exists ({exc}). Skipping.")
+            if exc.error_code != 400 or "already exists" not in str(exc.message):
+                logger.debug(f"Error migrating dictionary: {exc}")
+                raise exc
+
+            logger.debug(f"Dictionary already exists: {exc}")
             return target_dict, MigrateStatus.SKIPPED
         else:
             return target_dict, MigrateStatus.CREATED
@@ -643,19 +621,19 @@ def migrate_function(
         target_function: str
 ):
     """Migrates a single function."""
+    log_message(LogType.INFO, f"Migrating function '{target_function}'...", indent=0)
     function_settings = json.loads(basic_show(source_profile, source_functs_path, source_function))
     try:
-        try:
-            del function_settings["uuid"]
-        except KeyError:
-            pass
-
         function_settings["name"] = target_function
+        function_settings = normalize_function(function_settings)
+
         basic_create_from_dict_body(target_profile, target_functs_path, function_settings)
     except HttpException as exc:
-        if exc.error_code != 400:
-            logger.debug(f"Error creating function: {exc}")
-            raise
+        if exc.error_code != 400 or "already exists" not in str(exc.message):
+            logger.debug(f"Error migrating function: {exc}")
+            raise exc
+
+        logger.debug(f"Function already exists: {exc}")
         return target_function, MigrateStatus.SKIPPED
     else:
         return target_function, MigrateStatus.CREATED

--- a/src/hdx_cli/cli_interface/common/migration_rollback.py
+++ b/src/hdx_cli/cli_interface/common/migration_rollback.py
@@ -1,0 +1,141 @@
+from dataclasses import dataclass
+from enum import Enum
+from typing import List
+from urllib.parse import urlparse
+
+
+from ..common.undecorated_click_commands import basic_delete
+from ...library_api.common.logging import get_logger
+from ...library_api.common.generic_resource import access_resource_detailed
+from ...library_api.common.context import ProfileUserContext
+
+logger = get_logger()
+
+
+class MigrateStatus(Enum):
+    CREATED = 0
+    SKIPPED = 1
+
+
+class ResourceKind(Enum):
+    PROJECT = 0
+    TABLE = 1
+    TRANSFORM = 2
+    FUNCTION = 3
+    DICTIONARY = 4
+
+
+@dataclass(frozen=True)
+class MigrationEntry:
+    name: str
+    resource_kind: ResourceKind = ResourceKind.PROJECT
+    parents: List[str] = None
+
+
+class MigrationRollbackManager:
+    def __init__(self, profile):
+        self._profile: ProfileUserContext = profile
+        self.migration_entries_stack: List[MigrationEntry] = []
+
+    def push_entry(self, entry: MigrationEntry):
+        self.migration_entries_stack.append(entry)
+
+    def pop_entry(self):
+        if len(self.migration_entries_stack) != 0:
+            return self.migration_entries_stack.pop(-1)
+        return None
+
+    def _rollback_entry(self, entry: MigrationEntry):
+        """Rollback entry. Does not check for migrate_status and does it unconditionally"""
+        if entry.resource_kind == ResourceKind.PROJECT:
+            _, project_url = access_resource_detailed(self._profile,
+                                     [('projects', entry.name)])
+            split_path = urlparse(project_url).path.split('/')
+            resource_path = '/'.join(split_path[:-2])
+            if basic_delete(self._profile, resource_path, entry.name):
+                logger.info(f'Rolled back project {entry.name}')
+        elif entry.resource_kind == ResourceKind.FUNCTION:
+            _, function_url = access_resource_detailed(self._profile,
+                                                    [('projects', entry.parents[0]),
+                                                     ('functions', entry.name)])
+            split_path = urlparse(function_url).path.split('/')
+            resource_path = '/'.join(split_path[:-2])
+            if basic_delete(self._profile, resource_path, entry.name):
+                logger.info(f'Rolled back function {entry.name}')
+
+        elif entry.resource_kind == ResourceKind.DICTIONARY:
+            _, dict_url = access_resource_detailed(self._profile,
+                                                    [('projects', entry.parents[0]),
+                                                     ('dictionaries', entry.name)])
+            split_path = urlparse(dict_url).path.split('/')
+            resource_path = '/'.join(split_path[:-2])
+            if basic_delete(self._profile, resource_path, entry.name):
+                logger.info(f'Rolled back dictionary {entry.name}')
+        elif entry.resource_kind == ResourceKind.TABLE:
+            _, table_url = access_resource_detailed(self._profile,
+                                                    [('projects', entry.parents[0]),
+                                                     ('tables', entry.name)])
+            split_path = urlparse(table_url).path.split('/')
+            resource_path = '/'.join(split_path[:-2])
+            if basic_delete(self._profile, resource_path, entry.name):
+                logger.info(f'Rolled back table {entry.name}')
+        elif entry.resource_kind == ResourceKind.TRANSFORM:
+            _, transform_url = access_resource_detailed(self._profile,
+                                                        [('projects', entry.parents[0]),
+                                                         ('tables', entry.parents[1]),
+                                                         ('transforms', entry.name)])
+            split_path = urlparse(transform_url).path.split('/')
+            resource_path = '/'.join(split_path[:-2])
+            if basic_delete(self._profile, resource_path, entry.name):
+                logger.info(f'Rolled back transform {entry.name}')
+
+    def _rollback(self):
+        current_entry = self.pop_entry()
+        if not current_entry:
+            return
+        logger.info('Rolling back migration changes...')
+        while current_entry:
+            self._rollback_entry(current_entry)
+            current_entry = self.pop_entry()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type_, value, traceback):
+
+        if not traceback:
+            return
+        #logger.info('Rolling back migration changes...')
+        done = False
+        while not done:
+            try:
+                self._rollback()
+                done = True
+            except KeyboardInterrupt:
+                logger.info('A rollback was in progress, '
+                            'are you sure you want to abort without rolling back? [Y/n]: [!n]')
+                result = input('')
+                done = result.lower() == 'y'
+
+
+class DoNothingMigrationRollbackManager:
+    def __init__(self, profile):
+        pass
+
+    def push_entry(self, entry: MigrationEntry):
+        pass
+
+    def pop_entry(self):
+        pass
+
+    def _rollback_entry(self, entry: MigrationEntry):
+        pass
+
+    def _rollback(self):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type_, value, traceback):
+        pass

--- a/src/hdx_cli/cli_interface/common/migrations.py
+++ b/src/hdx_cli/cli_interface/common/migrations.py
@@ -1,254 +1,661 @@
 import io
+import json
 
 from urllib.parse import urlparse
 
-from ...library_api.common.auth_utils import load_user_context, generate_temporal_profile
-from ...library_api.common.context import ProfileLoadContext, ProfileUserContext
-from ...library_api.common.exceptions import HttpException
+from .migration_rollback import (
+    MigrationRollbackManager,
+    DoNothingMigrationRollbackManager,
+    MigrationEntry,
+    ResourceKind,
+    MigrateStatus
+)
+from ..common.undecorated_click_commands import basic_create_from_dict_body, basic_show
+from ...library_api.common.auth_utils import get_profile
+from ...library_api.common.context import ProfileUserContext
+from ...library_api.common.exceptions import HttpException, HdxCliException
 from ...library_api.common import rest_operations as lro
 from ...library_api.common.generic_resource import access_resource_detailed
-from ...library_api.common.config_constants import PROFILE_CONFIG_FILE
-from ..common.undecorated_click_commands import basic_create_from_dict_body
+from ...library_api.common.logging import get_logger
 
 
-def migrate_a_project(source_profile,
-                      project_name,
-                      target_profile_name,
-                      target_cluster_hostname,
-                      target_cluster_username,
-                      target_cluster_password,
-                      target_cluster_uri_scheme):
-    target_profile = get_target_profile(target_profile_name,
-                                        target_cluster_hostname,
-                                        target_cluster_username,
-                                        target_cluster_password,
-                                        target_cluster_uri_scheme,
-                                        source_profile.timeout)
-
-    source_project_body, _ = access_resource_detailed(source_profile, [('projects', project_name)])
-    _, target_projects_url = access_resource_detailed(target_profile, [('projects', None)])
-    target_projects_path = urlparse(target_projects_url).path
-
-    # Deleting invalid keys for table creation.
-    try:
-        del source_project_body['uuid']
-    except KeyError:
-        pass
-    # Creating resource on target cluster.
-    basic_create_from_dict_body(target_profile, target_projects_path, source_project_body)
+logger = get_logger()
 
 
-def migrate_a_table(source_profile,
-                    table_name,
-                    target_profile_name,
-                    target_cluster_hostname,
-                    target_cluster_username,
-                    target_cluster_password,
-                    target_cluster_uri_scheme,
-                    target_project_name):
-    target_profile = get_target_profile(target_profile_name,
-                                        target_cluster_hostname,
-                                        target_cluster_username,
-                                        target_cluster_password,
-                                        target_cluster_uri_scheme,
-                                        source_profile.timeout)
+def migrate_resource_config(
+        resource_type: str,
+        source_profile: ProfileUserContext,
+        target_profile_name: str,
+        target_cluster_hostname: str,
+        target_cluster_username: str,
+        target_cluster_password: str,
+        target_cluster_uri_scheme: str,
+        no_rollback: bool,
+        **kwargs
+):
+    """
+    Main method to migrate different types of resources.
+    It performs a login profile if needed,
+    and then calls the specific function based on the resource type.
 
-    source_table_body, _ = access_resource_detailed(source_profile,
-                                                    [('projects', source_profile.projectname),
-                                                     ('tables', table_name)])
-    _, target_tables_url = access_resource_detailed(target_profile,
-                                                    [('projects', target_project_name),
-                                                     ('tables', None)])
-    target_tables_path = urlparse(target_tables_url).path
+    Args:
+        resource_type (str): The type of resource to migrate. Supported values include:
+            - "project": To migrate projects.
+            - "table": To migrate tables.
+            - "transform": To migrate transforms.
+            - "dictionary": To migrate dictionaries.
+            - "function": To migrate functions.
+        source_profile (ProfileUserContext): The source profile context containing the connection
+            details and configuration for the source cluster.
+        target_profile_name (str): The name of the target profile for migration.
+        target_cluster_hostname (str): The hostname of the target cluster.
+        target_cluster_username (str): The username for authenticating with the target cluster.
+        target_cluster_password (str): The password for authenticating with the target cluster.
+        target_cluster_uri_scheme (str): The URI scheme for the target cluster (e.g., "http" or "https").
+        no_rollback (bool): If True, the migration will not be rolled back in case of an error.
+        **kwargs: Additional arguments specific to the resource being migrated. These may include
+            resource-specific configurations or settings.
 
-    try:
-        del source_table_body['uuid']
-        del source_table_body['settings']['autoingest'][0]['source']
-    except KeyError:
-        pass
-    basic_create_from_dict_body(target_profile, target_tables_path, source_table_body)
+    Raises:
+        HdxCliException: If the resource type is unknown or unsupported.
+    """
+    resource_migration_methods = {
+        "project": migrate_projects,
+        "table": migrate_tables,
+        "transform": migrate_transforms,
+        "dictionary": migrate_dictionaries,
+        "function": migrate_functions
+    }
+    migration_method = resource_migration_methods.get(resource_type)
+
+    if not migration_method:
+        raise HdxCliException(f"Unknown or unsupported migration resource type: {resource_type}")
+
+    target_profile = get_profile(
+        target_profile_name,
+        target_cluster_hostname,
+        target_cluster_username,
+        target_cluster_password,
+        target_cluster_uri_scheme,
+        source_profile.timeout
+    )
+
+    mrm = MigrationRollbackManager
+    if no_rollback:
+        mrm = DoNothingMigrationRollbackManager
+    with mrm(target_profile) as migration_rollback_manager:
+        # Call the specific migration function with the provided arguments
+        migration_method(
+            source_profile=source_profile,
+            target_profile=target_profile,
+            rollback_manager=migration_rollback_manager,
+            **kwargs
+        )
 
 
-def migrate_a_transform(
+def log_migration_status(
+        resource_type: str,
+        resource_name: str,
+        status: MigrateStatus,
+        rollback_manager: MigrationRollbackManager,
+        resource_kind: ResourceKind,
+        parents: list[str] = None
+):
+    """
+    Logs the migration status of a resource.
+
+    Args:
+        resource_type (str): The type of resource being migrated.
+        resource_name (str): The name of the resource.
+        status (MigrateStatus): The status of the migration.
+        rollback_manager (MigrationRollbackManager): The rollback manager instance.
+        resource_kind (ResourceKind): The kind of the resource.
+        parents (list[str]): The list of parent resources, if any.
+    """
+    logger.info(f"{resource_type} {resource_name}: [!n]")
+    if status == MigrateStatus.CREATED:
+        logger.info("Created Successfully")
+        m_entry = MigrationEntry(resource_name, resource_kind, parents)
+        rollback_manager.push_entry(m_entry)
+    elif status == MigrateStatus.SKIPPED:
+        logger.info("Skipped (was found)")
+
+
+def migrate_projects(
         source_profile: ProfileUserContext,
         target_profile: ProfileUserContext,
-        new_transform_name: str,
-        target_project_name: str,
-        target_table_name: str,
-        force_operation: bool
+        rollback_manager: MigrationRollbackManager | DoNothingMigrationRollbackManager,
+        source_project: str,
+        target_project: str,
+        only: bool = False,
+        dicts: bool = False,
+        functs: bool = False
 ):
-    source_transform_body, _ = access_resource_detailed(
+    _, source_projects_url = access_resource_detailed(source_profile, [("projects", None)])
+    _, target_projects_url = access_resource_detailed(target_profile, [("projects", None)])
+    source_projects_path = urlparse(source_projects_url).path
+    target_projects_path = urlparse(target_projects_url).path
+
+    project_name, status = migrate_project(
         source_profile,
-        [
-            ('projects', source_profile.projectname),
-            ('tables', source_profile.tablename),
-            ('transforms', source_profile.transformname)
+        target_profile,
+        source_projects_path,
+        target_projects_path,
+        source_project,
+        target_project
+    )
+    log_migration_status("Project", project_name, status, rollback_manager, ResourceKind.PROJECT)
+
+    if dicts:
+        migrate_dictionaries(
+            source_profile,
+            target_profile,
+            rollback_manager,
+            source_project,
+            target_project
+        )
+    if functs:
+        migrate_functions(
+            source_profile,
+            target_profile,
+            rollback_manager,
+            source_project,
+            target_project
+        )
+
+    if only:
+        return
+
+    migrate_tables(
+        source_profile,
+        target_profile,
+        rollback_manager,
+        source_project,
+        target_project,
+        only=only
+    )
+
+
+def migrate_project(
+        source_profile: ProfileUserContext,
+        target_profile: ProfileUserContext,
+        source_projects_path: str,
+        target_projects_path: str,
+        source_project: str,
+        target_project: str
+):
+    try:
+        project_settings = json.loads(basic_show(source_profile, source_projects_path, source_project))
+        try:
+            del project_settings["uuid"]
+        except KeyError:
+            pass
+
+        project_settings["name"] = target_project
+        basic_create_from_dict_body(target_profile, target_projects_path, project_settings)
+    except HttpException as exc:
+        if exc.error_code != 400:
+            logger.debug(f"Error creating project: {exc}")
+            raise
+        return target_project, MigrateStatus.SKIPPED
+    else:
+        return target_project, MigrateStatus.CREATED
+
+
+def migrate_tables(
+        source_profile: ProfileUserContext,
+        target_profile: ProfileUserContext,
+        rollback_manager: MigrationRollbackManager | DoNothingMigrationRollbackManager,
+        source_project: str,
+        target_project: str,
+        *,
+        source_table: str = None,
+        target_table: str = None,
+        only: bool = False
+):
+    tables, source_tables_url = access_resource_detailed(
+        source_profile, [("projects", source_project), ("tables", None)]
+    )
+    _, target_tables_url = access_resource_detailed(
+        target_profile, [("projects", target_project), ("tables", None)]
+    )
+    source_tables_path = urlparse(source_tables_url).path
+    target_tables_path = urlparse(target_tables_url).path
+
+    if source_table and target_table:
+        source_table_info = next((tbl for tbl in tables if tbl["name"] == source_table), {})
+        # If summary type, there won't be transform to be migrated
+        summary = source_table_info.get("type") == "summary"
+
+        _migrate_single_table_with_optionals(
+            source_profile,
+            target_profile,
+            rollback_manager,
+            source_tables_path,
+            target_tables_path,
+            source_project,
+            target_project,
+            source_table,
+            target_table,
+            only or summary
+        )
+        return
+
+    tables_sorted = sorted(tables, key=lambda tbl: tbl["type"], reverse=True)
+
+    for table in tables_sorted:
+        table_name = table.get("name")
+        # If summary type, there won't be transform to be migrated
+        summary = table.get("type") == "summary"
+
+        _migrate_single_table_with_optionals(
+            source_profile,
+            target_profile,
+            rollback_manager,
+            source_tables_path,
+            target_tables_path,
+            source_project,
+            target_project,
+            table_name,
+            table_name,
+            only or summary
+        )
+
+
+def _migrate_single_table_with_optionals(
+        source_profile: ProfileUserContext,
+        target_profile: ProfileUserContext,
+        rollback_manager: MigrationRollbackManager | DoNothingMigrationRollbackManager,
+        source_tables_path: str,
+        target_tables_path: str,
+        source_project: str,
+        target_project: str,
+        source_table: str,
+        target_table: str,
+        only: bool
+):
+    _, status = migrate_table(
+        source_profile,
+        target_profile,
+        source_tables_path,
+        target_tables_path,
+        source_table,
+        target_table
+    )
+    log_migration_status(
+        "Table",
+        target_table,
+        status,
+        rollback_manager,
+        ResourceKind.TABLE,
+        [target_project]
+    )
+
+    if only:
+        return
+
+    migrate_transforms(
+        source_profile,
+        target_profile,
+        rollback_manager,
+        source_project,
+        target_project,
+        source_table,
+        target_table
+    )
+
+
+def migrate_table(
+        source_profile: ProfileUserContext,
+        target_profile: ProfileUserContext,
+        source_tables_path: str,
+        target_tables_path: str,
+        source_table: str,
+        target_table: str
+):
+    """Migrates a single table."""
+    table_settings = json.loads(basic_show(source_profile, source_tables_path, source_table))
+    try:
+        try:
+            del table_settings["uuid"]
+            del table_settings["settings"]["autoingest"][0]["source"]
+        except KeyError:
+            pass
+
+        table_settings["name"] = target_table
+        basic_create_from_dict_body(target_profile, target_tables_path, table_settings)
+    except HttpException as exc:
+        if exc.error_code != 400:
+            logger.debug(f"Error creating table: {exc}")
+            raise
+        return target_table, MigrateStatus.SKIPPED
+    else:
+        return target_table, MigrateStatus.CREATED
+
+
+def migrate_transforms(
+        source_profile: ProfileUserContext,
+        target_profile: ProfileUserContext,
+        rollback_manager: MigrationRollbackManager | DoNothingMigrationRollbackManager,
+        source_project: str,
+        target_project: str,
+        source_table: str,
+        target_table: str,
+        *,
+        source_transform: str = None,
+        target_transform: str = None
+):
+    transforms, source_transforms_url = access_resource_detailed(
+        source_profile, [
+            ("projects", source_project),
+            ("tables", source_table),
+            ("transforms", None)
         ]
     )
     _, target_transforms_url = access_resource_detailed(
-        target_profile,
-        [
-            ('projects', target_project_name),
-            ('tables', target_table_name),
-            ('transforms', None)
+        target_profile, [
+            ("projects", target_project),
+            ("tables", target_table),
+            ("transforms", None)
         ]
     )
+    source_transforms_path = urlparse(source_transforms_url).path
     target_transforms_path = urlparse(target_transforms_url).path
-    source_transform_body['name'] = new_transform_name
-    try:
-        del source_transform_body['uuid']
-    except KeyError:
-        pass
 
-    params = {'force_operation': str(force_operation).lower()}
-    basic_create_from_dict_body(
-        target_profile,
-        target_transforms_path,
-        source_transform_body,
-        params=params
+    if source_transform and target_transform:
+        _, status = migrate_transform(
+            source_profile,
+            target_profile,
+            source_transforms_path,
+            target_transforms_path,
+            source_transform,
+            target_transform
+        )
+        log_migration_status(
+            "Transform",
+            target_transform,
+            status,
+            rollback_manager,
+            ResourceKind.TRANSFORM,
+            [target_project, target_table]
+        )
+        return
+
+    for transform in transforms:
+        transform_name = transform.get("name")
+        _, status = migrate_transform(
+            source_profile,
+            target_profile,
+            source_transforms_path,
+            target_transforms_path,
+            transform_name,
+            transform_name
+        )
+        log_migration_status(
+            "Transform",
+            transform_name,
+            status,
+            rollback_manager,
+            ResourceKind.TRANSFORM,
+            [target_project, target_table]
+        )
+
+
+def migrate_transform(
+        source_profile: ProfileUserContext,
+        target_profile: ProfileUserContext,
+        source_transforms_path: str,
+        target_transforms_path: str,
+        source_transform: str,
+        target_transform: str
+):
+    """Migrates a single transform."""
+    transform_settings = json.loads(
+        basic_show(source_profile, source_transforms_path, source_transform)
+    )
+    try:
+        try:
+            del transform_settings["uuid"]
+        except KeyError:
+            pass
+
+        transform_settings["name"] = target_transform
+        basic_create_from_dict_body(target_profile, target_transforms_path, transform_settings)
+    except HttpException as exc:
+        if exc.error_code != 400:
+            logger.debug(f"Error creating transform: {exc}")
+            raise
+        return target_transform, MigrateStatus.SKIPPED
+    else:
+        return target_transform, MigrateStatus.CREATED
+
+
+def migrate_dictionaries(
+        source_profile: ProfileUserContext,
+        target_profile: ProfileUserContext,
+        rollback_manager: MigrationRollbackManager | DoNothingMigrationRollbackManager,
+        source_project: str,
+        target_project: str,
+        *,
+        source_dictionary: str = None,
+        target_dictionary: str = None
+):
+    dicts, source_dicts_url = access_resource_detailed(
+        source_profile, [("projects", source_project), ("dictionaries", None)]
+    )
+    _, target_dicts_url = access_resource_detailed(
+        target_profile, [("projects", target_project), ("dictionaries", None)]
+    )
+    source_dicts_path = urlparse(source_dicts_url).path
+    target_dicts_path = urlparse(target_dicts_url).path
+
+    if source_dictionary and target_dictionary:
+        _, status = migrate_dictionary(
+            source_profile,
+            target_profile,
+            source_dicts_path,
+            target_dicts_path,
+            source_project,
+            target_project,
+            source_dictionary,
+            target_dictionary
+        )
+        log_migration_status(
+            "Dictionary",
+            target_dictionary,
+            status,
+            rollback_manager,
+            ResourceKind.DICTIONARY,
+            [target_project]
+        )
+        return
+
+    for dictionary in dicts:
+        dictionary_name = dictionary.get("name")
+        dict_name, status = migrate_dictionary(
+            source_profile,
+            target_profile,
+            source_dicts_path,
+            target_dicts_path,
+            source_project,
+            target_project,
+            dictionary_name,
+            dictionary_name
+        )
+        log_migration_status(
+            "Dictionary",
+            dictionary_name,
+            status,
+            rollback_manager,
+            ResourceKind.DICTIONARY,
+            [target_project]
+        )
+
+
+def migrate_dictionary(
+        source_profile: ProfileUserContext,
+        target_profile: ProfileUserContext,
+        source_dicts_path: str,
+        target_dicts_path: str,
+        source_project: str,
+        target_project: str,
+        source_dict: str,
+        target_dict: str
+):
+    """Migrates a single dictionary."""
+    dictionary = json.loads(basic_show(source_profile, source_dicts_path, source_dict))
+
+    d_settings = dictionary["settings"]
+    d_name = dictionary["name"]
+    d_file = d_settings["filename"]
+    d_format = d_settings["format"]
+    table_name = f"{source_project}_{d_name}"
+    query_endpoint = (
+        f"{source_profile.scheme}://{source_profile.hostname}"
+        f"/query/?query=SELECT * FROM {table_name} FORMAT {d_format}"
+    )
+    headers = {
+        "Authorization": f"{source_profile.auth.token_type} {source_profile.auth.token}",
+        "Accept": "*/*"
+    }
+    timeout = source_profile.timeout
+    dict_file_contents = lro.get(query_endpoint, headers=headers, timeout=timeout, fmt="verbatim")
+
+    try:
+        _create_dictionary_file_for_project(
+            target_profile,
+            target_project,
+            d_file,
+            dict_file_contents
+        )
+    except HttpException as exc:
+        if exc.error_code != 400:
+            logger.debug(f"Error creating dictionary file for project: {exc}")
+            raise
+        logger.debug(f"Dictionary file {d_file} already exists ({exc}). Skipping.")
+    finally:
+        try:
+            dictionary["name"] = target_dict
+            try:
+                del dictionary["uuid"]
+            except KeyError:
+                pass
+            basic_create_from_dict_body(target_profile, target_dicts_path, dictionary)
+        except HttpException as exc:
+            if exc.error_code != 400:
+                logger.debug(f"Error creating dictionary for project: {exc}")
+                raise
+            logger.debug(f"Dictionary {target_dict} already exists ({exc}). Skipping.")
+            return target_dict, MigrateStatus.SKIPPED
+        else:
+            return target_dict, MigrateStatus.CREATED
+
+
+def _create_dictionary_file_for_project(
+        profile: ProfileUserContext,
+        project: str,
+        dict_file: str,
+        dict_file_contents: bytes
+):
+    """Migrates a single dictionary file."""
+    _, project_url = access_resource_detailed(profile, [("projects", project)])
+
+    headers = {
+        "Authorization": f"{profile.auth.token_type} {profile.auth.token}",
+        "Accept": "*/*"
+    }
+    file_url = f'{project_url}dictionaries/files/'
+    timeout = profile.timeout
+
+    lro.create_file(
+        file_url,
+        headers=headers,
+        file_stream=io.BytesIO(dict_file_contents),
+        remote_filename=dict_file,
+        timeout=timeout
     )
 
 
-def migrate_a_dictionary(source_profile,
-                         dictionary_name,
-                         target_profile_name,
-                         target_cluster_hostname,
-                         target_cluster_username,
-                         target_cluster_password,
-                         target_cluster_uri_scheme,
-                         target_project_name):
-    target_profile = get_target_profile(target_profile_name,
-                                        target_cluster_hostname,
-                                        target_cluster_username,
-                                        target_cluster_password,
-                                        target_cluster_uri_scheme,
-                                        source_profile.timeout)
+def migrate_functions(
+        source_profile: ProfileUserContext,
+        target_profile: ProfileUserContext,
+        rollback_manager: MigrationRollbackManager | DoNothingMigrationRollbackManager,
+        source_project: str,
+        target_project: str,
+        *,
+        source_function: str = None,
+        target_function: str = None
+):
+    functs, source_functs_url = access_resource_detailed(
+        source_profile, [("projects", source_project), ("functions", None)]
+    )
+    _, target_functs_url = access_resource_detailed(
+        target_profile, [("projects", target_project), ("functions", None)]
+    )
+    source_functs_path = urlparse(source_functs_url).path
+    target_functs_path = urlparse(target_functs_url).path
 
-    source_dictionaries_body, _ = access_resource_detailed(source_profile,
-                                                           [('projects', source_profile.projectname),
-                                                            ('dictionaries', dictionary_name)])
-    _, target_dictionaries_url = access_resource_detailed(target_profile,
-                                                          [('projects', target_project_name),
-                                                           ('dictionaries', None)])
-    target_dictionaries_path = urlparse(target_dictionaries_url).path
+    if source_function and target_function:
+        _, status = migrate_function(
+            source_profile,
+            target_profile,
+            source_functs_path,
+            target_functs_path,
+            source_function,
+            target_function
+        )
+        log_migration_status(
+            "Function",
+            target_function,
+            status,
+            rollback_manager,
+            ResourceKind.FUNCTION,
+            [target_project]
+        )
+        return
 
-    _migrate_dict_file(source_profile, target_profile, source_dictionaries_body,
-                       source_profile.projectname, target_project_name)
+    for function in functs:
+        funct_name = function.get("name")
+        _, status = migrate_function(
+            source_profile,
+            target_profile,
+            source_functs_path,
+            target_functs_path,
+            funct_name,
+            funct_name
+        )
+        log_migration_status(
+            "Function",
+            funct_name,
+            status,
+            rollback_manager,
+            ResourceKind.FUNCTION,
+            [target_project]
+        )
 
+
+def migrate_function(
+        source_profile: ProfileUserContext,
+        target_profile: ProfileUserContext,
+        source_functs_path: str,
+        target_functs_path: str,
+        source_function: str,
+        target_function: str
+):
+    """Migrates a single function."""
+    function_settings = json.loads(basic_show(source_profile, source_functs_path, source_function))
     try:
-        del source_dictionaries_body['uuid']
-    except KeyError:
-        pass
-    basic_create_from_dict_body(target_profile, target_dictionaries_path, source_dictionaries_body)
+        try:
+            del function_settings["uuid"]
+        except KeyError:
+            pass
 
-
-def migrate_a_function(source_profile,
-                       function_name,
-                       target_profile_name,
-                       target_cluster_hostname,
-                       target_cluster_username,
-                       target_cluster_password,
-                       target_cluster_uri_scheme,
-                       target_project_name):
-    target_profile = get_target_profile(target_profile_name,
-                                        target_cluster_hostname,
-                                        target_cluster_username,
-                                        target_cluster_password,
-                                        target_cluster_uri_scheme,
-                                        source_profile.timeout)
-
-    source_function_body, _ = access_resource_detailed(source_profile,
-                                                       [('projects', source_profile.projectname),
-                                                        ('functions', function_name)])
-    _, target_functions_url = access_resource_detailed(target_profile,
-                                                       [('projects', target_project_name),
-                                                        ('functions', None)])
-    target_functions_path = urlparse(target_functions_url).path
-
-    try:
-        del source_function_body['uuid']
-    except KeyError:
-        pass
-    basic_create_from_dict_body(target_profile, target_functions_path, source_function_body)
-
-
-def migrate_a_storage(source_profile,
-                      storage_name,
-                      target_profile_name,
-                      target_cluster_hostname,
-                      target_cluster_username,
-                      target_cluster_password,
-                      target_cluster_uri_scheme):
-    target_profile = get_target_profile(target_profile_name,
-                                        target_cluster_hostname,
-                                        target_cluster_username,
-                                        target_cluster_password,
-                                        target_cluster_uri_scheme,
-                                        source_profile.timeout)
-
-    source_storages_body, _ = access_resource_detailed(source_profile,
-                                                       [('storages', storage_name)])
-    _, target_storages_url = access_resource_detailed(target_profile,
-                                                      [('storages', None)])
-    target_storages_path = urlparse(target_storages_url).path
-
-    try:
-        del source_storages_body['uuid']
-    except KeyError:
-        pass
-    basic_create_from_dict_body(target_profile, target_storages_path, source_storages_body)
-
-
-def get_target_profile(target_profile_name,
-                       target_cluster_hostname,
-                       target_cluster_username,
-                       target_cluster_password,
-                       target_cluster_uri_scheme,
-                       target_timeout):
-    if target_profile_name:
-        load_context = ProfileLoadContext(target_profile_name, PROFILE_CONFIG_FILE)
-        target_profile = load_user_context(load_context)
+        function_settings["name"] = target_function
+        basic_create_from_dict_body(target_profile, target_functs_path, function_settings)
+    except HttpException as exc:
+        if exc.error_code != 400:
+            logger.debug(f"Error creating function: {exc}")
+            raise
+        return target_function, MigrateStatus.SKIPPED
     else:
-        target_profile = generate_temporal_profile(target_cluster_hostname,
-                                                   target_cluster_username,
-                                                   target_cluster_password,
-                                                   target_cluster_uri_scheme)
-    target_profile.timeout = target_timeout
-    return target_profile
-
-
-def _migrate_dict_file(source_profile, target_profile, dictionary, source_project_name, target_project_name):
-    d_settings = dictionary['settings']
-    d_name = dictionary['name']
-    d_file = d_settings['filename']
-    d_format = d_settings['format']
-    table_name = f'{source_project_name}_{d_name}'
-    query_endpoint = (f'{source_profile.scheme}://{source_profile.hostname}'
-                      f'/query/?query=SELECT * FROM {table_name} FORMAT {d_format}')
-    headers = {'Authorization': f'{source_profile.auth.token_type} {source_profile.auth.token}',
-               'Accept': '*/*'}
-    timeout = source_profile.timeout
-    contents = lro.get(query_endpoint, headers=headers, timeout=timeout, fmt='verbatim')
-    try:
-        _create_dictionary_file_for_project(target_project_name, d_file, contents,
-                                            target_profile)
-    except HttpException:
-        # Dictionary file existed, no need to create it
-        pass
-
-
-def _create_dictionary_file_for_project(project_name,
-                                        dict_file,
-                                        contents,
-                                        profile: ProfileUserContext):
-    _, project_url = access_resource_detailed(profile,
-                                              [('projects', project_name)])
-
-    headers = {'Authorization': f'{profile.auth.token_type} {profile.auth.token}',
-               'Accept': '*/*'}
-    file_url = f'{project_url}dictionaries/files/'
-    timeout = profile.timeout
-    lro.create_file(file_url, headers=headers,
-                    file_stream=io.BytesIO(contents),
-                    remote_filename=dict_file,
-                    timeout=timeout)
+        return target_function, MigrateStatus.CREATED

--- a/src/hdx_cli/cli_interface/common/undecorated_click_commands.py
+++ b/src/hdx_cli/cli_interface/common/undecorated_click_commands.py
@@ -135,7 +135,12 @@ def basic_show(profile,
     for resource in resources:
         if resource.get(filter_field) == resource_name:
             return json.dumps(resource, indent=indentation)
-    raise ResourceNotFoundException('Cannot find resource.')
+
+    if resource_name is not None:
+        message = f"Resource with {filter_field} '{resource_name}' not found."
+    else:
+        message = "Cannot find resource."
+    raise ResourceNotFoundException(message)
 
 
 def basic_transform(ctx: click.Context):
@@ -152,34 +157,36 @@ def basic_transform(ctx: click.Context):
     token = profile_info.auth
     headers = {'Authorization': f'{token.token_type} {token.token}',
                'Accept': 'application/json'}
-    projects_list = rest_ops.list(list_projects_url,
-                                  headers=headers,
-                                  timeout=timeout)
 
     try:
+        projects_list = rest_ops.list(list_projects_url,
+                                      headers=headers,
+                                      timeout=timeout)
         project_id = [p['uuid'] for p in projects_list if p['name'] == project_name][0]
+    except IndexError as idx_err:
+        raise LogicException(f"Project '{project_name}' not found.") from idx_err
 
+    try:
         list_tables_url = f'{scheme}://{hostname}/config/v1/orgs/{org_id}/projects/{project_id}/tables'
         tables_list = rest_ops.list(list_tables_url,
                                     headers=headers,
                                     timeout=timeout)
         table_id = [t['uuid'] for t in tables_list if t['name'] == table_name][0]
+    except IndexError as idx_err:
+        raise LogicException(f"Table '{table_name}' not found.") from idx_err
 
-        transforms_path = f'/config/v1/orgs/{org_id}/projects/{project_id}/tables/{table_id}/transforms/'
+    transforms_path = f'/config/v1/orgs/{org_id}/projects/{project_id}/tables/{table_id}/transforms/'
+
+    if profile_info.transformname:
         transforms_url = f'{scheme}://{hostname}{transforms_path}'
-
         transforms_list = rest_ops.list(transforms_url,
                                         headers=headers,
                                         timeout=timeout)
-    except IndexError as idx_err:
-        raise LogicException('Cannot find resource.') from idx_err
-
-    if profile_info.transformname:
         try:
             transform_name = [t['name'] for t in transforms_list if t['name'] == profile_info.transformname][0]
             profile_info.transformname = transform_name
         except IndexError as ex:
-            raise TransformNotFoundException(f'Transform not found: {profile_info.transformname}') from ex
+            raise TransformNotFoundException(f"Transform '{profile_info.transformname}' not found.") from ex
     ctx.obj = {'resource_path': transforms_path,
                'usercontext': profile_info}
 

--- a/src/hdx_cli/cli_interface/dictionary/commands.py
+++ b/src/hdx_cli/cli_interface/dictionary/commands.py
@@ -2,7 +2,7 @@
 import json
 import click
 
-from ..common.migrations import migrate_a_dictionary
+from ..common.migrations import migrate_resource_config
 from ..common.misc_operations import settings as command_settings
 from ..common.undecorated_click_commands import (
     basic_create,
@@ -14,7 +14,12 @@ from ..common.rest_operations import (
     show as command_show
 )
 from ...library_api.common.generic_resource import access_resource
-from ...library_api.utility.decorators import report_error_and_exit, ensure_logged_in
+from ...library_api.utility.decorators import (
+    report_error_and_exit,
+    ensure_logged_in,
+    target_cluster_options,
+    no_rollback_option
+)
 from ...library_api.common.exceptions import (
     ResourceNotFoundException,
     MissingSettingsException,
@@ -146,38 +151,52 @@ def dict_file_delete(ctx: click.Context, dictionary_filename):
     logger.info(f'Deleted {dictionary_filename}')
 
 
-@click.command(help='Migrate a dictionary.', name='migrate')
-@click.argument('dictionary_name', metavar='DICTIONARY_NAME', required=True, default=None)
-@click.option('-tp', '--target-profile', required=False, default=None)
-@click.option('-h', '--target-cluster-hostname', required=False, default=None)
-@click.option('-u', '--target-cluster-username', required=False, default=None)
-@click.option('-p', '--target-cluster-password', required=False, default=None)
-@click.option('-s', '--target-cluster-uri-scheme', required=False, default='https')
-@click.option('-P', '--target-project-name', required=True, default=None)
+@click.command(
+    help=(
+        "Migrate a dictionary to a target project and profile.\n\n"
+        "This command migrates a dictionary from the current source profile to the specified "
+        "target project and target profile. The target profile can be provided directly using "
+        "the --target-profile option, or by specifying the target cluster details such as "
+        "hostname, username, password, and URI scheme."
+    ), name='migrate'
+)
+@click.argument('target_project_name', metavar='TARGET_PROJECT_NAME', required=True, default=None)
+@click.argument('new_dictionary_name', metavar='NEW_DICTIONARY_NAME', required=True, default=None)
+@target_cluster_options
+@no_rollback_option
 @click.pass_context
 @report_error_and_exit(exctype=Exception)
 def migrate_dictionary(ctx: click.Context,
-                       dictionary_name: str,
-                       target_profile,
-                       target_cluster_hostname,
-                       target_cluster_username,
-                       target_cluster_password,
-                       target_cluster_uri_scheme,
-                       target_project_name):
+                       target_project_name: str,
+                       new_dictionary_name: str,
+                       target_profile: str,
+                       target_cluster_hostname: str,
+                       target_cluster_username: str,
+                       target_cluster_password: str,
+                       target_cluster_uri_scheme: str,
+                       no_rollback: bool):
+    source_profile = ctx.parent.obj['usercontext']
+
+    if not source_profile.dictionaryname:
+        raise click.BadParameter('No source dictionary provided.')
     if target_profile is None and not (target_cluster_hostname and target_cluster_username
                                        and target_cluster_password and target_cluster_uri_scheme):
         raise click.BadParameter('Either provide a --target-profile or all four target cluster options.')
 
-    user_profile = ctx.parent.obj['usercontext']
-    migrate_a_dictionary(user_profile,
-                         dictionary_name,
-                         target_profile,
-                         target_cluster_hostname,
-                         target_cluster_username,
-                         target_cluster_password,
-                         target_cluster_uri_scheme,
-                         target_project_name)
-    logger.info(f'Migrated dictionary {dictionary_name}')
+    data = {
+        "source_profile": source_profile,
+        "target_profile_name": target_profile,
+        "target_cluster_hostname": target_cluster_hostname,
+        "target_cluster_username": target_cluster_username,
+        "target_cluster_password": target_cluster_password,
+        "target_cluster_uri_scheme": target_cluster_uri_scheme,
+        "source_project": source_profile.projectname,
+        "target_project": target_project_name,
+        "source_dictionary": source_profile.dictionaryname,
+        "target_dictionary": new_dictionary_name,
+        "no_rollback": no_rollback,
+    }
+    migrate_resource_config('dictionary', **data)
 
 
 dictionary.add_command(create_dict, name='create')

--- a/src/hdx_cli/cli_interface/dictionary/commands.py
+++ b/src/hdx_cli/cli_interface/dictionary/commands.py
@@ -2,7 +2,7 @@
 import json
 import click
 
-from ..common.migrations import migrate_resource_config
+from ..common.migration.resource_migrations import migrate_resource_config
 from ..common.misc_operations import settings as command_settings
 from ..common.undecorated_click_commands import (
     basic_create,
@@ -197,6 +197,8 @@ def migrate_dictionary(ctx: click.Context,
         "no_rollback": no_rollback,
     }
     migrate_resource_config('dictionary', **data)
+
+    logger.info('All resources migrated successfully')
 
 
 dictionary.add_command(create_dict, name='create')

--- a/src/hdx_cli/cli_interface/function/commands.py
+++ b/src/hdx_cli/cli_interface/function/commands.py
@@ -2,7 +2,7 @@
 import json
 import click
 
-from ..common.migrations import migrate_resource_config
+from ..common.migration.resource_migrations import migrate_resource_config
 from ..common.rest_operations import (
     delete as command_delete,
     list_ as command_list,
@@ -153,6 +153,8 @@ def migrate(ctx: click.Context,
         "no_rollback": no_rollback,
     }
     migrate_resource_config('function', **data)
+
+    logger.info('All resources migrated successfully')
 
 
 function.add_command(create)

--- a/src/hdx_cli/cli_interface/function/commands.py
+++ b/src/hdx_cli/cli_interface/function/commands.py
@@ -2,7 +2,7 @@
 import json
 import click
 
-from ..common.migrations import migrate_a_function
+from ..common.migrations import migrate_resource_config
 from ..common.rest_operations import (
     delete as command_delete,
     list_ as command_list,
@@ -10,10 +10,14 @@ from ..common.rest_operations import (
 )
 from ..common.misc_operations import settings as command_settings
 from ...library_api.common.generic_resource import access_resource
-from ...library_api.userdata.token import AuthInfo
 from ...library_api.common import rest_operations as rest_ops
 from ...library_api.common.context import ProfileUserContext
-from ...library_api.utility.decorators import report_error_and_exit, ensure_logged_in
+from ...library_api.utility.decorators import (
+    report_error_and_exit,
+    ensure_logged_in,
+    target_cluster_options,
+    no_rollback_option
+)
 from ...library_api.common.exceptions import LogicException, ResourceNotFoundException
 from ...library_api.common.logging import get_logger
 
@@ -103,40 +107,52 @@ def create(ctx: click.Context,
     logger.info(f'Created function {function_name}')
 
 
-@click.command(help='Migrate a function.')
-@click.argument('function_name', metavar='FUNCTION_NAME', required=True, default=None)
-@click.option('-tp', '--target-profile', required=False, default=None)
-@click.option('-h', '--target-cluster-hostname', required=False, default=None)
-@click.option('-u', '--target-cluster-username', required=False, default=None)
-@click.option('-p', '--target-cluster-password', required=False, default=None)
-@click.option('-s', '--target-cluster-uri-scheme', required=False, default='https')
-@click.option('-P', '--target-project-name', required=True, default=None)
+@click.command(
+    help=(
+        "Migrate a function to a target project and profile.\n\n"
+        "This command migrates a function from the current source profile to the specified "
+        "target project and target profile. The target profile can be provided directly using "
+        "the --target-profile option, or by specifying the target cluster details such as "
+        "hostname, username, password, and URI scheme."
+    )
+)
+@click.argument('target_project_name', metavar='TARGET_PROJECT_NAME', required=True, default=None)
+@click.argument('new_function_name', metavar='FUNCTION_NAME', required=True, default=None)
+@target_cluster_options
+@no_rollback_option
 @click.pass_context
 @report_error_and_exit(exctype=Exception)
 def migrate(ctx: click.Context,
-            function_name: str,
-            target_profile,
-            target_cluster_hostname,
-            target_cluster_username,
-            target_cluster_password,
-            target_cluster_uri_scheme,
-            target_project_name):
+            target_project_name: str,
+            new_function_name: str,
+            target_profile: str,
+            target_cluster_hostname: str,
+            target_cluster_username: str,
+            target_cluster_password: str,
+            target_cluster_uri_scheme: str,
+            no_rollback: bool):
+    source_profile = ctx.parent.obj['usercontext']
+
+    if not source_profile.functionname:
+        raise click.BadParameter('No source function provided.')
     if target_profile is None and not (target_cluster_hostname and target_cluster_username
                                        and target_cluster_password and target_cluster_uri_scheme):
         raise click.BadParameter('Either provide a --target-profile or all four target cluster options.')
 
-    user_profile = ctx.parent.obj['usercontext']
-    migrate_a_function(
-        user_profile,
-        function_name,
-        target_profile,
-        target_cluster_hostname,
-        target_cluster_username,
-        target_cluster_password,
-        target_cluster_uri_scheme,
-        target_project_name
-    )
-    logger.info(f'Migrated function {function_name}')
+    data = {
+        "source_profile": source_profile,
+        "target_profile_name": target_profile,
+        "target_cluster_hostname": target_cluster_hostname,
+        "target_cluster_username": target_cluster_username,
+        "target_cluster_password": target_cluster_password,
+        "target_cluster_uri_scheme": target_cluster_uri_scheme,
+        "source_project": source_profile.projectname,
+        "target_project": target_project_name,
+        "source_function": source_profile.functionname,
+        "target_function": new_function_name,
+        "no_rollback": no_rollback,
+    }
+    migrate_resource_config('function', **data)
 
 
 function.add_command(create)

--- a/src/hdx_cli/cli_interface/migrate/commands_v2.py
+++ b/src/hdx_cli/cli_interface/migrate/commands_v2.py
@@ -7,8 +7,8 @@ from .helpers import MigrationData, get_catalog
 from .rc.rc_manager import RcloneAPIConfig
 from .resources import get_resources, create_resources
 from .validator import validations
-from ..common.migrations import get_target_profile
 from ..profile.commands import validate_hostname
+from ...library_api.common.auth_utils import get_profile
 from ...library_api.utility.decorators import report_error_and_exit, ensure_logged_in
 from ...library_api.common.logging import get_logger
 
@@ -100,7 +100,7 @@ def migrate(ctx: click.Context,
         )
 
     else:
-        target_profile = get_target_profile(
+        target_profile = get_profile(
             target_profile_name,
             target_hostname,
             target_username,

--- a/src/hdx_cli/cli_interface/migrate/resource_adapter.py
+++ b/src/hdx_cli/cli_interface/migrate/resource_adapter.py
@@ -1,9 +1,9 @@
 import re
 
-from hdx_cli.cli_interface.common.undecorated_click_commands import get_resource_settings_structure
-from hdx_cli.cli_interface.migrate.helpers import confirm_action
-from hdx_cli.library_api.common.context import ProfileUserContext
-from hdx_cli.library_api.common.logging import get_logger
+from ..common.undecorated_click_commands import get_resource_settings_structure
+from ..migrate.helpers import confirm_action
+from ...library_api.common.context import ProfileUserContext
+from ...library_api.common.logging import get_logger
 
 logger = get_logger()
 
@@ -21,7 +21,7 @@ def prompt_user_for_value(key: str, message=None, default=None):
     return user_input if user_input else default
 
 
-def adapt_table_merge_pools(pools: dict) -> dict | None:
+def _adapt_table_merge_pools(pools: dict) -> dict | None:
     logger.info("In progress")
     logger.info(f"{' Merge Pools Settings ':*^40}")
     logger.info("* Current merge pools settings for SOURCE table")
@@ -39,7 +39,7 @@ def adapt_table_merge_pools(pools: dict) -> dict | None:
     return updated_pools if updated_pools else None
 
 
-def adapt_table_autoingest(autoingest: dict) -> dict | None:
+def _adapt_table_autoingest(autoingest: dict) -> dict | None:
     logger.info("In progress")
     logger.info(f"{' Autoingest Settings ':*^40}")
     logger.info("* Current autoingest settings for SOURCE table")
@@ -61,7 +61,7 @@ def adapt_table_autoingest(autoingest: dict) -> dict | None:
     return autoingest if autoingest else None
 
 
-def extract_table_name_from_sql(sql):
+def _extract_table_name_from_sql(sql):
     pattern = r"(?i)\bFROM\s+([`\"']?\w+[`\"']?\.\w+)"
     match = re.search(pattern, sql)
     if not match:
@@ -72,7 +72,7 @@ def extract_table_name_from_sql(sql):
     return project, table
 
 
-def update_parent_in_summary_sql(summary_settings: dict) -> dict:
+def _update_parent_in_summary_sql(summary_settings: dict) -> dict:
     logger.info("In progress")
     logger.info(f"{' Summary Settings ':*^40}")
 
@@ -84,7 +84,7 @@ def update_parent_in_summary_sql(summary_settings: dict) -> dict:
         sql = get_user_value_input("sql", "string")
         logger.info("*")
 
-    current_project, current_table = extract_table_name_from_sql(sql)
+    current_project, current_table = _extract_table_name_from_sql(sql)
 
     current_summary_parents = (
         "Not Found"
@@ -132,7 +132,7 @@ def normalize_project(project: dict, reuse_partitions: bool) -> dict:
 
 
 def normalize_summary_table(summary_settings: dict) -> dict:
-    return update_parent_in_summary_sql(summary_settings)
+    return _update_parent_in_summary_sql(summary_settings)
 
 
 def normalize_table(table: dict, reuse_partitions: bool) -> dict:
@@ -152,7 +152,7 @@ def normalize_table(table: dict, reuse_partitions: bool) -> dict:
     if autoingest and isinstance(autoingest, list):
         for element in autoingest:
             if isinstance(element, dict) and element.get("enabled"):
-                updated_element = adapt_table_autoingest(element)
+                updated_element = _adapt_table_autoingest(element)
                 if updated_element:
                     filtered_autoingest.append(updated_element)
 
@@ -164,7 +164,7 @@ def normalize_table(table: dict, reuse_partitions: bool) -> dict:
     # Merge pools
     merge = table_settings.get("merge")
     if merge and isinstance(merge, dict) and (pools := merge.get("pools")):
-        updated_pools = adapt_table_merge_pools(pools)
+        updated_pools = _adapt_table_merge_pools(pools)
         if updated_pools:
             merge["pools"] = updated_pools
         else:

--- a/src/hdx_cli/cli_interface/project/commands.py
+++ b/src/hdx_cli/cli_interface/project/commands.py
@@ -10,8 +10,13 @@ from ..common.rest_operations import (
     stats as command_stats
 )
 from ..common.misc_operations import settings as command_settings
-from ..common.migrations import migrate_a_project
-from ...library_api.utility.decorators import report_error_and_exit, ensure_logged_in
+from ..common.migrations import migrate_resource_config
+from ...library_api.utility.decorators import (
+    report_error_and_exit,
+    ensure_logged_in,
+    no_rollback_option,
+    target_cluster_options
+)
 from ...library_api.common.context import ProfileUserContext
 from ...library_api.common.logging import get_logger
 
@@ -50,37 +55,65 @@ def create(ctx: click.Context, project_name: str):
     logger.info(f'Created project {project_name}')
 
 
-@click.command(help='Migrate a project.')
-@click.argument('project_name', metavar='PROJECT_NAME', required=True, default=None)
-@click.option('-tp', '--target-profile', required=False, default=None)
-@click.option('-h', '--target-cluster-hostname', required=False, default=None)
-@click.option('-u', '--target-cluster-username', required=False, default=None)
-@click.option('-p', '--target-cluster-password', required=False, default=None)
-@click.option('-s', '--target-cluster-uri-scheme', required=False, default='https')
+@click.command(
+    help=(
+        "Migrate a project and its associated resources.\n\n"
+        "This command migrates a project from the source profile to the specified target profile "
+        "or cluster. By default, all resources associated with the project are also migrated, "
+        "including tables (and their associated transforms).\n\n"
+        "Options allow you to customize the migration:\n"
+        "- Use --dictionaries (-D) to include dictionaries in the migration.\n"
+        "- Use --functions (-F) to include functions in the migration.\n"
+        "- Use --only (-O) to migrate only the project, skipping all dependencies.\n\n"
+        "Provide a target profile using --target-profile or specify cluster details "
+        "(hostname, username, password, and URI scheme)."
+    )
+)
+@click.argument('new_project_name', metavar='NEW_PROJECT_NAME', required=True, default=None)
+@target_cluster_options
+@no_rollback_option
+@click.option('-O', '--only', required=False, default=False, is_flag=True,
+              help='Migrate only the project, skipping dependencies.')
+@click.option('-D', '--dictionaries', required=False, default=False, is_flag=True,
+              help='Migrate dictionaries associated with the project.')
+@click.option('-F', '--functions', required=False, default=False, is_flag=True,
+              help='Migrate functions associated with the project.')
 @click.pass_context
 @report_error_and_exit(exctype=Exception)
 def migrate(ctx: click.Context,
-            project_name: str,
+            new_project_name: str,
             target_profile: str,
             target_cluster_hostname: str,
             target_cluster_username: str,
             target_cluster_password: str,
-            target_cluster_uri_scheme: str):
+            target_cluster_uri_scheme: str,
+            no_rollback: bool,
+            only: bool,
+            dictionaries: bool,
+            functions: bool):
+    source_profile = ctx.parent.obj['usercontext']
+
+    if not source_profile.projectname:
+        raise click.BadParameter('No source project name provided.')
     if target_profile is None and not (target_cluster_hostname and target_cluster_username
                                        and target_cluster_password and target_cluster_uri_scheme):
         raise click.BadParameter('Either provide a --target-profile or all four target cluster options.')
 
-    user_profile = ctx.parent.obj['usercontext']
-    migrate_a_project(
-        user_profile,
-        project_name,
-        target_profile,
-        target_cluster_hostname,
-        target_cluster_username,
-        target_cluster_password,
-        target_cluster_uri_scheme
-    )
-    logger.info(f'Migrated project {project_name}')
+    data = {
+        "source_profile": source_profile,
+        "target_profile_name": target_profile,
+        "target_cluster_hostname": target_cluster_hostname,
+        "target_cluster_username": target_cluster_username,
+        "target_cluster_password": target_cluster_password,
+        "target_cluster_uri_scheme": target_cluster_uri_scheme,
+        "source_project": source_profile.projectname,
+        "target_project": new_project_name,
+        "no_rollback": no_rollback,
+        "only": only,
+        "dicts": dictionaries,
+        "functs": functions,
+    }
+    migrate_resource_config('project', **data)
 
 
 project.add_command(command_list)

--- a/src/hdx_cli/cli_interface/project/commands.py
+++ b/src/hdx_cli/cli_interface/project/commands.py
@@ -10,7 +10,7 @@ from ..common.rest_operations import (
     stats as command_stats
 )
 from ..common.misc_operations import settings as command_settings
-from ..common.migrations import migrate_resource_config
+from ..common.migration.resource_migrations import migrate_resource_config
 from ...library_api.utility.decorators import (
     report_error_and_exit,
     ensure_logged_in,
@@ -114,6 +114,8 @@ def migrate(ctx: click.Context,
         "functs": functions,
     }
     migrate_resource_config('project', **data)
+
+    logger.info('All resources migrated successfully')
 
 
 project.add_command(command_list)

--- a/src/hdx_cli/cli_interface/storage/commands.py
+++ b/src/hdx_cli/cli_interface/storage/commands.py
@@ -3,7 +3,6 @@ from functools import partial
 
 import click
 
-from ..common.migrations import migrate_a_storage
 from ..common.rest_operations import list_ as command_list, show as command_show
 from ..common.undecorated_click_commands import (
     basic_create_from_dict_body,
@@ -167,40 +166,8 @@ def settings(ctx: click.Context,
     basic_settings(user_profile, resource_path, key, the_value, params=params)
 
 
-@click.command(help='Migrate a storage.')
-@click.argument('storage_name', metavar='STORAGE_NAME', required=True, default=None)
-@click.option('-tp', '--target-profile', required=False, default=None)
-@click.option('-h', '--target-cluster-hostname', required=False, default=None)
-@click.option('-u', '--target-cluster-username', required=False, default=None)
-@click.option('-p', '--target-cluster-password', required=False, default=None)
-@click.option('-s', '--target-cluster-uri-scheme', required=False, default='https')
-@click.pass_context
-@report_error_and_exit(exctype=Exception)
-def migrate(ctx: click.Context,
-            storage_name: str,
-            target_profile,
-            target_cluster_hostname,
-            target_cluster_username,
-            target_cluster_password,
-            target_cluster_uri_scheme):
-    if target_profile is None and not (target_cluster_hostname and target_cluster_username
-                                       and target_cluster_password and target_cluster_uri_scheme):
-        raise click.BadParameter('Either provide a --target-profile or all four target cluster options.')
-
-    user_profile = ctx.parent.obj['usercontext']
-    migrate_a_storage(user_profile,
-                      storage_name,
-                      target_profile,
-                      target_cluster_hostname,
-                      target_cluster_username,
-                      target_cluster_password,
-                      target_cluster_uri_scheme)
-    logger.info(f'Migrated storage {storage_name}')
-
-
 storage.add_command(command_list)
 storage.add_command(create)
 storage.add_command(delete)
 storage.add_command(command_show)
 storage.add_command(settings)
-storage.add_command(migrate)

--- a/src/hdx_cli/cli_interface/table/commands.py
+++ b/src/hdx_cli/cli_interface/table/commands.py
@@ -2,7 +2,7 @@
 import click
 import requests
 
-from ..common.migrations import migrate_a_table
+from ..common.migrations import migrate_resource_config
 from ..common.rest_operations import (
     delete as command_delete,
     list_ as command_list,
@@ -14,11 +14,15 @@ from ..common.misc_operations import settings as command_settings
 from ..common.undecorated_click_commands import basic_create_from_dict_body
 from ...library_api.common import rest_operations as rest_ops
 from ...library_api.common.generic_resource import access_resource
-from ...library_api.utility.decorators import report_error_and_exit, ensure_logged_in
+from ...library_api.utility.decorators import (
+    report_error_and_exit,
+    ensure_logged_in,
+    target_cluster_options,
+    no_rollback_option
+)
 from ...library_api.common.exceptions import LogicException, ResourceNotFoundException
 from ...library_api.common.context import ProfileUserContext
 from ...library_api.common.logging import get_logger
-from ...library_api.userdata.token import AuthInfo
 from ...library_api.utility.file_handling import load_json_settings_file, load_plain_file
 
 logger = get_logger()
@@ -145,38 +149,59 @@ def command_truncate(ctx: click.Context,
     logger.info(f'Truncated table {table_name}')
 
 
-@click.command(help='Migrate a table.')
-@click.argument('table_name', metavar='TABLE_NAME', required=True, default=None)
-@click.option('-tp', '--target-profile', required=False, default=None)
-@click.option('-h', '--target-cluster-hostname', required=False, default=None)
-@click.option('-u', '--target-cluster-username', required=False, default=None)
-@click.option('-p', '--target-cluster-password', required=False, default=None)
-@click.option('-s', '--target-cluster-uri-scheme', required=False, default='https')
-@click.option('-P', '--target-project-name', required=True, default=None)
+@click.command(
+    help=(
+        "Migrate a table and its associated transforms.\n\n"
+        "This command migrates a table from the source project in the current profile to a "
+        "target project and profile. By default, the associated transforms within the table "
+        "are also migrated.\n\n"
+        "Options allow you to customize the migration:\n"
+        "- Use --only (-O) to migrate only the table, skipping all associated transforms.\n\n"
+        "Provide a target profile using --target-profile or specify cluster details "
+        "(hostname, username, password, and URI scheme)."
+    )
+)
+@click.argument('target_project_name', metavar='TARGET_PROJECT_NAME', required=True, default=None)
+@click.argument('new_table_name', metavar='NEW_TABLE_NAME', required=True, default=None)
+@target_cluster_options
+@no_rollback_option
+@click.option('-O', '--only', required=False, default=False, is_flag=True,
+              help='Migrate only the table, skipping its associated transforms.')
 @click.pass_context
 @report_error_and_exit(exctype=Exception)
 def migrate(ctx: click.Context,
-            table_name: str,
-            target_profile,
-            target_cluster_hostname,
-            target_cluster_username,
-            target_cluster_password,
-            target_cluster_uri_scheme,
-            target_project_name):
+            target_project_name: str,
+            new_table_name: str,
+            target_profile: str,
+            target_cluster_hostname: str,
+            target_cluster_username: str,
+            target_cluster_password: str,
+            target_cluster_uri_scheme: str,
+            no_rollback: bool,
+            only: bool):
+    source_profile = ctx.parent.obj['usercontext']
+
+    if not source_profile.tablename:
+        raise click.BadParameter('No source table name provided.')
     if target_profile is None and not (target_cluster_hostname and target_cluster_username
                                        and target_cluster_password and target_cluster_uri_scheme):
         raise click.BadParameter('Either provide a --target-profile or all four target cluster options.')
 
-    user_profile = ctx.parent.obj['usercontext']
-    migrate_a_table(user_profile,
-                    table_name,
-                    target_profile,
-                    target_cluster_hostname,
-                    target_cluster_username,
-                    target_cluster_password,
-                    target_cluster_uri_scheme,
-                    target_project_name)
-    logger.info(f'Migrated table {table_name}')
+    data = {
+        "source_profile": source_profile,
+        "target_profile_name": target_profile,
+        "target_cluster_hostname": target_cluster_hostname,
+        "target_cluster_username": target_cluster_username,
+        "target_cluster_password": target_cluster_password,
+        "target_cluster_uri_scheme": target_cluster_uri_scheme,
+        "source_project": source_profile.projectname,
+        "target_project": target_project_name,
+        "source_table": source_profile.tablename,
+        "target_table": new_table_name,
+        "no_rollback": no_rollback,
+        "only": only,
+    }
+    migrate_resource_config('table', **data)
 
 
 table.add_command(create)

--- a/src/hdx_cli/cli_interface/table/commands.py
+++ b/src/hdx_cli/cli_interface/table/commands.py
@@ -2,7 +2,7 @@
 import click
 import requests
 
-from ..common.migrations import migrate_resource_config
+from ..common.migration.resource_migrations import migrate_resource_config
 from ..common.rest_operations import (
     delete as command_delete,
     list_ as command_list,
@@ -202,6 +202,8 @@ def migrate(ctx: click.Context,
         "only": only,
     }
     migrate_resource_config('table', **data)
+
+    logger.info('All resources migrated successfully')
 
 
 table.add_command(create)

--- a/src/hdx_cli/cli_interface/transform/commands.py
+++ b/src/hdx_cli/cli_interface/transform/commands.py
@@ -5,7 +5,7 @@ import json
 
 import click
 
-from ..common.migrations import migrate_resource_config
+from ..common.migration.resource_migrations import migrate_resource_config
 from ..common.undecorated_click_commands import basic_transform
 from ..common.misc_operations import settings_with_force as command_settings_with_force
 from ..common.undecorated_click_commands import basic_create_with_body_from_string
@@ -211,6 +211,8 @@ def migrate(ctx: click.Context,
         "no_rollback": no_rollback,
     }
     migrate_resource_config('transform', **data)
+
+    logger.info('All resources migrated successfully')
 
 
 transform.add_command(map_from)

--- a/src/hdx_cli/cli_interface/transform/commands.py
+++ b/src/hdx_cli/cli_interface/transform/commands.py
@@ -5,7 +5,7 @@ import json
 
 import click
 
-from ..common.migrations import migrate_a_transform, get_target_profile
+from ..common.migrations import migrate_resource_config
 from ..common.undecorated_click_commands import basic_transform
 from ..common.misc_operations import settings_with_force as command_settings_with_force
 from ..common.undecorated_click_commands import basic_create_with_body_from_string
@@ -17,7 +17,9 @@ from ..common.rest_operations import (
 from ...library_api.utility.decorators import (
     report_error_and_exit,
     ensure_logged_in,
-    force_operation_option
+    force_operation_option,
+    target_cluster_options,
+    no_rollback_option
 )
 from ...library_api.common.exceptions import CommandLineException
 from ...library_api.common.context import ProfileUserContext
@@ -157,52 +159,58 @@ def map_from(ctx: click.Context,
     logger.info(f'Created transform {transform_name}')
 
 
-@click.command(help='Migrate a table.')
+@click.command(
+    help=(
+        "Migrate a transform to a target project and table.\n\n"
+        "This command migrates a transform from the source project and table in the current profile "
+        "to a specified target project and table in the target profile or cluster.\n\n"
+        "Provide a target profile using --target-profile or specify cluster details "
+        "(hostname, username, password, and URI scheme)."
+    )
+)
+@click.argument('target_project_name', metavar='TARGET_PROJECT_NAME', required=True, default=None)
+@click.argument('target_table_name', metavar='TARGET_TABLE_NAME', required=True, default=None)
 @click.argument('new_transform_name', metavar='NEW_TRANSFORM_NAME', required=True, default=None)
-@click.option('-tp', '--target-profile', 'target_profile_name', required=False, default=None)
-@click.option('-h', '--target-cluster-hostname', required=False, default=None)
-@click.option('-u', '--target-cluster-username', required=False, default=None)
-@click.option('-p', '--target-cluster-password', required=False, default=None)
-@click.option('-s', '--target-cluster-uri-scheme', required=False, default='https')
-@click.option('-P', '--target-project-name', required=True, default=None)
-@click.option('-T', '--target-table-name', required=True, default=None)
-@force_operation_option
+@target_cluster_options
+@no_rollback_option
 @click.pass_context
 @report_error_and_exit(exctype=Exception)
 def migrate(ctx: click.Context,
+            target_project_name: str,
+            target_table_name: str,
             new_transform_name: str,
-            target_profile_name: str,
+            target_profile: str,
             target_cluster_hostname: str,
             target_cluster_username: str,
             target_cluster_password: str,
             target_cluster_uri_scheme: str,
-            target_project_name: str,
-            target_table_name: str,
-            force_operation: bool):
-    if target_profile_name is None and not (target_cluster_hostname and target_cluster_username
+            no_rollback: bool):
+    source_profile = ctx.parent.obj['usercontext']
+
+    if not source_profile.transformname:
+        raise click.BadParameter('No source transform provided.')
+    if target_profile is None and not (target_cluster_hostname and target_cluster_username
                                        and target_cluster_password and target_cluster_uri_scheme):
         raise click.BadParameter(
             'Either provide a --target-profile or all four target cluster options.'
         )
 
-    source_profile = ctx.parent.obj['usercontext']
-    target_profile = get_target_profile(
-        target_profile_name,
-        target_cluster_hostname,
-        target_cluster_username,
-        target_cluster_password,
-        target_cluster_uri_scheme,
-        source_profile.timeout
-    )
-    migrate_a_transform(
-        source_profile,
-        target_profile,
-        new_transform_name,
-        target_project_name,
-        target_table_name,
-        force_operation
-    )
-    logger.info(f"Migrated transform '{new_transform_name}'")
+    data = {
+        "source_profile": source_profile,
+        "target_profile_name": target_profile,
+        "target_cluster_hostname": target_cluster_hostname,
+        "target_cluster_username": target_cluster_username,
+        "target_cluster_password": target_cluster_password,
+        "target_cluster_uri_scheme": target_cluster_uri_scheme,
+        "source_project": source_profile.projectname,
+        "target_project": target_project_name,
+        "source_table": source_profile.tablename,
+        "target_table": target_table_name,
+        "source_transform": source_profile.transformname,
+        "target_transform": new_transform_name,
+        "no_rollback": no_rollback,
+    }
+    migrate_resource_config('transform', **data)
 
 
 transform.add_command(map_from)

--- a/src/hdx_cli/library_api/common/auth_utils.py
+++ b/src/hdx_cli/library_api/common/auth_utils.py
@@ -12,87 +12,126 @@ from .auth import load_profile, try_load_profile_from_cache_data, save_profile_c
 from .context import ProfileUserContext, ProfileLoadContext, DEFAULT_TIMEOUT
 from .exceptions import TokenExpiredException, HdxCliException
 from .login import login
-from .config_constants import HDX_CONFIG_DIR
+from .config_constants import HDX_CONFIG_DIR, PROFILE_CONFIG_FILE
+
 
 
 def load_user_context(load_context, **args):
-    load_set_params = ft.partial(_load_set_config_parameters,
-                                 load_context=load_context)
-
-    user_context = _chain_calls_ignore_exc(try_load_profile_from_cache_data,
-                                           fail_if_token_expired,
-                                           load_set_params,
-                                           # Parameters to first function
-                                           load_ctx=load_context,
-                                           # _chain_calls_ignore_exc Function configuration
-                                           exctype=HdxCliException)
+    load_set_params = ft.partial(_load_set_config_parameters, load_context=load_context)
+    user_context = _chain_calls_ignore_exc(
+        try_load_profile_from_cache_data,
+        fail_if_token_expired,
+        load_set_params,
+        # Parameters to first function
+        load_ctx=load_context,
+        # _chain_calls_ignore_exc Function configuration
+        exctype=HdxCliException
+    )
     if not user_context:
         user_context: ProfileUserContext = load_profile(load_context)
-        auth_info = login(user_context.username,
-                          user_context.hostname,
-                          password=args.get('password'),
-                          use_ssl=user_context.scheme == 'https')
+        auth_info = login(
+            user_context.username,
+            user_context.hostname,
+            password=args.get("password"),
+            use_ssl=user_context.scheme == "https"
+        )
         user_context.auth = auth_info
         user_context.org_id = auth_info.org_id
-        cache_dir_path = (Path(args.get('profile_config_file')).parent
-                          if args.get('profile_config_file') else HDX_CONFIG_DIR)
-        save_profile_cache(user_context,
-                           token=auth_info.token,
-                           expiration_time=auth_info.expires_at,
-                           token_type=auth_info.token_type,
-                           org_id=auth_info.org_id,
-                           cache_dir_path=cache_dir_path)
+        cache_dir_path = (Path(args.get("profile_config_file")).parent
+                          if args.get("profile_config_file") else HDX_CONFIG_DIR)
+        save_profile_cache(
+            user_context,
+            token=auth_info.token,
+            expiration_time=auth_info.expires_at,
+            token_type=auth_info.token_type,
+            org_id=auth_info.org_id,
+            cache_dir_path=cache_dir_path
+        )
         user_context.auth = auth_info
 
-    uri_scheme = args.get('uri_scheme')
-    timeout = args.get('timeout')
-    if uri_scheme and uri_scheme != 'default':
-        user_context.scheme = args.get('uri_scheme')
+    uri_scheme = args.get("uri_scheme")
+    timeout = args.get("timeout")
+    if uri_scheme and uri_scheme != "default":
+        user_context.scheme = args.get("uri_scheme")
     if timeout and timeout != DEFAULT_TIMEOUT:
         user_context.timeout = args.get('timeout')
 
     return user_context
 
 
-def generate_temporal_profile(cluster_hostname,
-                              cluster_username,
-                              cluster_password,
-                              cluster_uri_scheme):
-    target_profiles_file = Path(tempfile.gettempdir() + os.sep +
-                                cluster_username + '_' +
-                                cluster_hostname + '.toml')
-    _setup_target_cluster_config(target_profiles_file,
-                                 cluster_username,
-                                 cluster_hostname,
-                                 cluster_uri_scheme)
-    target_load_ctx = ProfileLoadContext('default', target_profiles_file)
-    auth_info = login(cluster_username,
-                      cluster_hostname,
-                      password=cluster_password,
-                      use_ssl=(cluster_uri_scheme == 'https'))
+def generate_temporal_profile(
+        cluster_hostname: str,
+        cluster_username: str,
+        cluster_password: str,
+        cluster_uri_scheme: str
+):
+    target_profiles_file = Path(
+        tempfile.gettempdir() + os.sep + cluster_username + '_' + cluster_hostname + '.toml'
+    )
+    _setup_target_cluster_config(
+        target_profiles_file,
+        cluster_username,
+        cluster_hostname,
+        cluster_uri_scheme
+    )
+    target_load_ctx = ProfileLoadContext("default", target_profiles_file)
+    auth_info = login(
+        cluster_username,
+        cluster_hostname,
+        password=cluster_password,
+        use_ssl=(cluster_uri_scheme == "https")
+    )
     temp_profile = load_profile(target_load_ctx)
     temp_profile.auth = auth_info
     temp_profile.org_id = auth_info.org_id
 
-    save_profile_cache(temp_profile,
-                       token=temp_profile.auth.token,
-                       org_id=temp_profile.org_id,
-                       token_type='Bearer',
-                       expiration_time=temp_profile.auth.expires_at,
-                       cache_dir_path=temp_profile.profile_config_file.parent)
+    save_profile_cache(
+        temp_profile,
+        token=temp_profile.auth.token,
+        org_id=temp_profile.org_id,
+        token_type="Bearer",
+        expiration_time=temp_profile.auth.expires_at,
+        cache_dir_path=temp_profile.profile_config_file.parent
+    )
+
     return temp_profile
 
 
-def _setup_target_cluster_config(profile_config_file,
-                                 target_cluster_username,
-                                 target_cluster_hostname,
-                                 target_cluster_scheme):
+def get_profile(
+        profile_name: str,
+        cluster_hostname: str,
+        cluster_username: str,
+        cluster_password: str,
+        cluster_uri_scheme: str,
+        timeout: int = DEFAULT_TIMEOUT
+):
+    if profile_name:
+        load_context = ProfileLoadContext(profile_name, PROFILE_CONFIG_FILE)
+        user_profile = load_user_context(load_context)
+    else:
+        user_profile = generate_temporal_profile(
+            cluster_hostname,
+            cluster_username,
+            cluster_password,
+            cluster_uri_scheme
+        )
+    user_profile.timeout = timeout
+    return user_profile
+
+
+def _setup_target_cluster_config(
+        profile_config_file: Path,
+        target_cluster_username: str,
+        target_cluster_hostname: str,
+        target_cluster_scheme: str
+):
     username = target_cluster_username
     hostname = target_cluster_hostname
     scheme = target_cluster_scheme
-    config_data = {'default': {'username': username, 'hostname': hostname, 'scheme': scheme}}
+    config_data = {"default": {"username": username, "hostname": hostname, "scheme": scheme}}
+    # Ensure the directory for the profile configuration file exists, creating it if necessary
     os.makedirs(Path(profile_config_file).parent, exist_ok=True)
-    with open(profile_config_file, 'w+', encoding='utf-8') as config_file:
+    with open(profile_config_file, 'w+', encoding='utf-8') as config_file: # type: ignore
         toml.dump(config_data, config_file)
 
 
@@ -106,14 +145,14 @@ def _chain_calls_ignore_exc(*funcs, **kwargs):
     are provided as input of the first function.
     """
     # Setup function
-    exctype = kwargs.get('exctype', Exception)
-    on_error_return = kwargs.get('on_error_return', None)
+    exctype = kwargs.get("exctype", Exception)
+    on_error_return = kwargs.get("on_error_return", None)
     try:
-        del kwargs['exctype']
+        del kwargs["exctype"]
     except: # pylint:disable=bare-except
         pass
     try:
-        del kwargs['on_error_return']
+        del kwargs["on_error_return"]
     except: # pylint:disable=bare-except
         pass
 
@@ -128,15 +167,17 @@ def _chain_calls_ignore_exc(*funcs, **kwargs):
         return on_error_return
 
 
-def _load_set_config_parameters(user_context: ProfileUserContext,
-                                load_context: ProfileLoadContext):
+def _load_set_config_parameters(
+        user_context: ProfileUserContext,
+        load_context: ProfileLoadContext
+):
     """Given a profile to load and an old profile, it returns the user_context
     with the config parameters projectname and tablename loaded."""
-    config_params = {'projectname':
-                     (prof := load_profile(load_context)).projectname,
-                     'tablename':
-                     prof.tablename,
-                     'scheme': prof.scheme}
+    config_params = {
+        "projectname": (prof := load_profile(load_context)).projectname,
+        "tablename": prof.tablename,
+        "scheme": prof.scheme
+    }
     user_ctx_dict = dc.asdict(user_context) | config_params
     # Keep old auth since asdict will transform AuthInfo into a dictionary.
     old_auth = user_context.auth

--- a/src/hdx_cli/library_api/common/generic_resource.py
+++ b/src/hdx_cli/library_api/common/generic_resource.py
@@ -2,6 +2,7 @@ from typing import Tuple, Optional, List, Any
 
 from . import rest_operations as rest_ops
 from .context import ProfileUserContext
+from .exceptions import ResourceNotFoundException
 
 ResourceKind = str
 ResourceName = str
@@ -43,7 +44,7 @@ def access_resource_detailed(ctx: ProfileUserContext,
                                  timeout=timeout)
         return (resource, resource_url)
 
-    for resource, resource_name in resource_kind_and_name:
+    for idx, (resource, resource_name) in enumerate(resource_kind_and_name):
         resource_url = f'{resource_url}{resource}/'
         resource_list = rest_ops.list(resource_url,
                                       headers=headers,
@@ -53,10 +54,14 @@ def access_resource_detailed(ctx: ProfileUserContext,
 
         a_resource = [r for r in resource_list if r['name'] == resource_name]
         if not a_resource:
+            if idx < len(resource_kind_and_name) - 1:  # More items to go through
+                raise ResourceNotFoundException(
+                    f"Resource '{resource_name}' not found.")
             return None, resource_url
 
         a_resource = a_resource[0]
         resource_url = f'{resource_url}{a_resource["uuid"]}/'
+
     if not resource_kind_and_name:
         pass
 

--- a/src/hdx_cli/library_api/utility/decorators.py
+++ b/src/hdx_cli/library_api/utility/decorators.py
@@ -106,8 +106,8 @@ def find_in_disk_cache(cache_file, namespace):
     return find_in_disk_cache_wrapper
 
 
-def ensure_logged_in(f):
-    @wraps(f)
+def ensure_logged_in(func):
+    @wraps(func)
     def decorated_function(ctx: click.Context, *args, **kwargs):
         profile_context = ctx.parent.obj['profilecontext']
         user_options = ctx.parent.obj['useroptions']
@@ -117,16 +117,16 @@ def ensure_logged_in(f):
                                          uri_scheme=user_options.get('uri_scheme'),
                                          timeout=user_options.get('timeout'))
         ctx.parent.obj['usercontext'] = user_context
-        return f(ctx, *args, **kwargs)
+        return func(ctx, *args, **kwargs)
     return decorated_function
 
 
-def with_profiles_context(f):
-    @functools.wraps(f)
+def with_profiles_context(func):
+    @functools.wraps(func)
     def decorated_function(ctx, *args, **kwargs):
         profile_context = ctx.parent.obj['profilecontext']
         config_profiles = get_profiles(profile_config_file=profile_context.profile_config_file)
-        return f(ctx, profile_context, config_profiles, *args, **kwargs)
+        return func(ctx, profile_context, config_profiles, *args, **kwargs)
     return decorated_function
 
 
@@ -138,4 +138,61 @@ def force_operation_option(func):
         default=False,
         help='This flag allows adding the "force_operation" parameter to the request.'
     )(func)
+    return func
+
+
+def no_rollback_option(func):
+    """
+    Decorator for handling the '--no-rollback' option.
+    If the user provides --no-rollback, then no_rollback == True.
+    Otherwise, it remains False by default.
+    """
+    func = click.option(
+        '--no-rollback',
+        is_flag=True,
+        default=False,
+        help='Disable rollback behavior in case of errors.'
+    )(func)
+    return func
+
+
+def target_cluster_options(func):
+    """
+    Decorator that adds all the common target cluster/profile options.
+    """
+    func = click.option(
+        '-tp', '--target-profile',
+        required=False,
+        default=None,
+        help="Name of an existing profile to connect to the target host."
+    )(func)
+
+    func = click.option(
+        '-h', '--target-cluster-hostname',
+        required=False,
+        default=None,
+        help="Hostname of the target cluster."
+    )(func)
+
+    func = click.option(
+        '-u', '--target-cluster-username',
+        required=False,
+        default=None,
+        help="Username to authenticate to the target cluster."
+    )(func)
+
+    func = click.option(
+        '-p', '--target-cluster-password',
+        required=False,
+        default=None,
+        help="Password for the target cluster user."
+    )(func)
+
+    func = click.option(
+        '-s', '--target-cluster-uri-scheme',
+        required=False,
+        default='https',
+        help="Protocol to use (http or https). Defaults to 'https'."
+    )(func)
+
     return func

--- a/src/hdx_cli/main.py
+++ b/src/hdx_cli/main.py
@@ -28,7 +28,7 @@ from hdx_cli.library_api.common.first_use import is_first_time_use, first_time_u
 from hdx_cli.library_api.common.logging import set_debug_logger, set_info_logger, get_logger
 from hdx_cli.cli_interface.set import commands as set_commands
 
-VERSION = "1.0-rc69"
+VERSION = "1.0-rc71"
 
 logger = get_logger()
 

--- a/tests/command_line_interface/test_cases/test_read_only_flows.ts
+++ b/tests/command_line_interface/test_cases/test_read_only_flows.ts
@@ -630,12 +630,13 @@ commands_under_test = ["python -m hdx_cli.main role add-user --user test_ci_invi
 teardown = ["python -m hdx_cli.main role delete --disable-confirmation-prompt new_role"]
 expected_output = 'Added user(s) to new_role role'
 
-[[test]]
-name = "Removed user from role"
-setup = ["python -m hdx_cli.main role create --name new_role --permission change_table"]
-commands_under_test = ["python3 -m hdx_cli.main role remove-user --user test_ci_invite_user@hydolix.io new_role"]
-teardown = ["python -m hdx_cli.main role delete --disable-confirmation-prompt new_role"]
-expected_output = 'Removed user(s) from new_role role'
+# Known bug -> HDX-6985
+#[[test]]
+#name = "Removed user from role"
+#setup = ["python -m hdx_cli.main role create --name new_role --permission change_table"]
+#commands_under_test = ["python3 -m hdx_cli.main role remove-user --user test_ci_invite_user@hydolix.io new_role"]
+#teardown = ["python -m hdx_cli.main role delete --disable-confirmation-prompt new_role"]
+#expected_output = 'Removed user(s) from new_role role'
 
 [[test]]
 name = "add nonexistent user to a role"
@@ -690,7 +691,7 @@ teardown = ["python -m hdx_cli.main user invite delete user_invite_cli@hydrolix.
 [[test]]
 name = "Assign role to non-exist user"
 commands_under_test = ["python3 -m hdx_cli.main user assign-role user_non-exist@hydrolix.io -r read_only"]
-expected_output = 'Error: Cannot find resource.'
+expected_output = "Error: Resource with email 'user_non-exist@hydrolix.io' not found."
 
 [[test]]
 name = "Assign non-exist role to user"
@@ -723,7 +724,7 @@ teardown = ["python -m hdx_cli.main user invite delete user_invite_cli@hydrolix.
 [[test]]
 name = "Delete not exist resource"
 commands_under_test = ["python3 -m hdx_cli.main user remove-role not_exist@hydrolix.io -r super_admin"]
-expected_output = 'Error: Cannot find resource.'
+expected_output = "Error: Resource with email 'not_exist@hydrolix.io' not found."
 teardown = ["python -m hdx_cli.main user invite delete user_invite_cli@hydrolix.io --disable-confirmation-prompt"]
 
 [[test]]
@@ -756,7 +757,7 @@ teardown = ["python -m hdx_cli.main user invite delete user_invite_cli@hydrolix.
 [[test]]
 name = "Resend invitation to a not exist user"
 commands_under_test = ["python3 -m hdx_cli.main user invite resend user_not_exist@hydrolix.io"]
-expected_output_re = 'Error: Cannot find resource.'
+expected_output_re = "Error: Resource with email 'user_not_exist@hydrolix.io' not found."
 
 [[test]]
 name = "Invitation list"
@@ -786,7 +787,7 @@ teardown = ["python -m hdx_cli.main user invite delete user_invite_cli@hydrolix.
 [[test]]
 name = "Invite to a user not exist can be show"
 commands_under_test = ["python3 -m hdx_cli.main user invite --user user_not_exist@hydrolix.io show"]
-expected_output_re = 'Error: Cannot find resource.'
+expected_output_re = "Error: Resource with email 'user_not_exist@hydrolix.io' not found."
 
 ################################################### query-options ####################################################
 [[test]]


### PR DESCRIPTION
This PR improves the migration commands for projects, tables, transforms, dictionaries, and functions by including dependencies and child resources during the migration process when necessary.

- **Project migration** now includes tables and transforms by default, with the option to skip them using the `--only` flag.
- Added optional flags `--functions` and `--dictionaries` to `project migrate` to allow migrating related resources like functions and dictionaries.
- **Table migration** now includes transforms by default, with the option to skip them using the `--only` flag.

### Additional Features:
- Implemented enhancements to the rollback process for resource migrations to ensure more robust error handling.
