### PR TITLE
Add credential command and refactor resource find methods

### DIFF
--- a/src/hdx_cli/cli_interface/common/cached_operations.py
+++ b/src/hdx_cli/cli_interface/common/cached_operations.py
@@ -11,147 +11,86 @@ from ...library_api.common.logging import get_logger
 logger = get_logger()
 
 
-def find_kafka(user_ctx: ProfileUserContext):
-    return access_resource(user_ctx,
-                           [('projects', user_ctx.projectname),
-                            ('tables', user_ctx.tablename),
-                            ('sources/kafka', None)])
+def find_kafka(user_ctx: ProfileUserContext) -> list[dict]:
+    return access_resource(
+        user_ctx,
+        [("projects", user_ctx.projectname),
+         ("tables", user_ctx.tablename),
+         ("sources/kafka", None)]
+    )
 
 
-def find_kinesis(user_ctx: ProfileUserContext):
-    return access_resource(user_ctx,
-                           [('projects', user_ctx.projectname),
-                            ('tables', user_ctx.tablename),
-                            ('sources/kinesis', None)])
+def find_kinesis(user_ctx: ProfileUserContext) -> list[dict]:
+    return access_resource(
+        user_ctx,
+        [("projects", user_ctx.projectname),
+         ("tables", user_ctx.tablename),
+         ("sources/kinesis", None)]
+    )
 
 
-def find_siem(user_ctx: ProfileUserContext):
-    return access_resource(user_ctx,
-                           [('projects', user_ctx.projectname),
-                            ('tables', user_ctx.tablename),
-                            ('sources/siem', None)])
+def find_siem(user_ctx: ProfileUserContext) -> list[dict]:
+    return access_resource(
+        user_ctx,
+        [("projects", user_ctx.projectname),
+         ("tables", user_ctx.tablename),
+         ("sources/siem", None)]
+    )
 
 
-def find_projects(user_ctx: ProfileUserContext):
-    token = user_ctx.auth
-    hostname = user_ctx.hostname
-    scheme = user_ctx.scheme
-    timeout = user_ctx.timeout
-    url = f"{scheme}://{hostname}/config/v1/orgs/{user_ctx.org_id}/projects/"
-    headers = {"Authorization": f"{token.token_type} {token.token}",
-               "Accept": "application/json"}
-    result = requests.get(url, headers=headers, timeout=timeout)
-    if result.status_code != 200:
-        raise HdxCliException(f"Error getting projects.")
-    return json.loads(result.content)
+def find_projects(user_ctx: ProfileUserContext) -> list[dict]:
+    return access_resource(user_ctx,[("projects", None)])
 
 
-def find_batch(user_ctx: ProfileUserContext):
-    token = user_ctx.auth
-    hostname = user_ctx.hostname
-    scheme = user_ctx.scheme
-    timeout = user_ctx.timeout
-    url = f"{scheme}://{hostname}/config/v1/orgs/{user_ctx.org_id}/jobs/batch/"
-    headers = {"Authorization": f"{token.token_type} {token.token}",
-               "Accept": "application/json"}
-    result = requests.get(url, headers=headers, timeout=timeout)
-    if result.status_code != 200:
-        raise HdxCliException("Error getting projects.")
-    return json.loads(result.content)
+def find_tables(user_ctx: ProfileUserContext) -> list[dict]:
+    return access_resource(user_ctx, [("projects", user_ctx.projectname), ("tables", None)])
+
+
+def find_dictionaries(user_ctx: ProfileUserContext) -> list[dict]:
+    return access_resource(user_ctx, [("projects", user_ctx.projectname), ("dictionaries", None)])
+
+
+def find_functions(user_ctx: ProfileUserContext) -> list[dict]:
+    return access_resource(user_ctx, [("projects", user_ctx.projectname), ("functions", None)])
+
+
+def find_batch(user_ctx: ProfileUserContext) -> list[dict]:
+    return access_resource(user_ctx, [("jobs/batch", None)])
+
+
+def find_transforms(user_ctx: ProfileUserContext) -> list[dict]:
+    return access_resource(
+        user_ctx,
+        [("projects", user_ctx.projectname),
+         ("tables", user_ctx.tablename),
+         ("transforms", None)]
+    )
+
+
+def find_storages(user_ctx: ProfileUserContext) -> list[dict]:
+    return access_resource(user_ctx, [("storages", None)])
+
+
+def find_pools(user_ctx: ProfileUserContext) -> list[dict]:
+    return access_resource(user_ctx, [("pools", None)], base_path="/config/v1/")
+
+
+def find_credentials(user_ctx: ProfileUserContext) -> list[dict]:
+    return access_resource(user_ctx, [("credentials", None)])
 
 
 @find_in_disk_cache(cache_file=HDX_CONFIG_DIR / "cache/cache.bin",
                     namespace="projects_ids")
-def find_project_id(user_ctx, project_name):
+def find_project_id(user_ctx: ProfileUserContext, project_name: str) -> list[str]:
     projects = find_projects(user_ctx)
     return [t["uuid"] for t in projects if t["name"] == project_name]
 
 
-def _find_project_resource(user_ctx: ProfileUserContext, resource):
-    """resource parameter is 'functions' or 'tables', 'dictionaries' or anything project-level"""
-    project_id = [ p for p in find_projects(user_ctx)
-                    if p["name"] == user_ctx.projectname][0]["uuid"]
-    token = user_ctx.auth
-    hostname = user_ctx.hostname
-    scheme = user_ctx.scheme
-    url = f"{scheme}://{hostname}/config/v1/orgs/{user_ctx.org_id}/projects/{project_id}/{resource}"
-    headers={"Authorization": f"{token.token_type} {token.token}",
-             "Accept": "application/json"}
-    result = requests.get(url, headers=headers)
-    if result.status_code != 200:
-        raise HdxCliException(f"Error getting projects.")
-    return json.loads(result.content)
-
-
-def find_tables(user_ctx: ProfileUserContext):
-    return _find_project_resource(user_ctx, 'tables')
-
-
-def find_dictionaries(user_ctx: ProfileUserContext):
-    return _find_project_resource(user_ctx, 'dictionaries')
-
-
-def find_functions(user_ctx: ProfileUserContext):
-    return _find_project_resource(user_ctx, 'functions')
-
-
 @find_in_disk_cache(cache_file=HDX_CONFIG_DIR / "cache/cache.bin",
                     namespace="tables_ids")
-def find_table_id(user_ctx, table_name):
+def find_table_id(user_ctx: ProfileUserContext, table_name: str) -> list[str]:
     tables = find_tables(user_ctx)
     return [t["uuid"] for t in tables if t["name"] == table_name]
-
-
-def find_transforms(user_ctx: ProfileUserContext):
-    try:
-        project_id = [p for p in find_projects(user_ctx) if p["name"] == user_ctx.projectname][0]["uuid"]
-    except IndexError as exc:
-        raise ResourceNotFoundException(f'Cannot find project name: {user_ctx.projectname}') from exc
-
-    try:
-        table_id = [p for p in find_tables(user_ctx) if p["name"] == user_ctx.tablename][0]["uuid"]
-    except IndexError as exc:
-        raise ResourceNotFoundException(f'Cannot find table name: {user_ctx.tablename}') from exc
-
-    token = user_ctx.auth
-    hostname = user_ctx.hostname
-    scheme = user_ctx.scheme
-    url = f"{scheme}://{hostname}/config/v1/orgs/{user_ctx.org_id}/projects/{project_id}/tables/{table_id}/transforms"
-    headers = {
-        "Authorization": f"{token.token_type} {token.token}",
-        "Accept": "application/json"}
-    result = requests.get(url, headers=headers)
-    if result.status_code != 200:
-        raise HdxCliException(f"Error getting projects.")
-    return json.loads(result.content)
-
-
-def find_storages(user_ctx: ProfileUserContext):
-    token = user_ctx.auth
-    hostname = user_ctx.hostname
-    scheme = user_ctx.scheme
-    timeout = user_ctx.timeout
-    url = f"{scheme}://{hostname}/config/v1/orgs/{user_ctx.org_id}/storages/"
-    headers = {"Authorization": f"{token.token_type} {token.token}",
-               "Accept": "application/json"}
-    result = requests.get(url, headers=headers, timeout=timeout)
-    if result.status_code != 200:
-        raise HdxCliException(f"Error getting storages.")
-    return json.loads(result.content)
-
-
-def find_pools(user_ctx: ProfileUserContext):
-    token = user_ctx.auth
-    hostname = user_ctx.hostname
-    scheme = user_ctx.scheme
-    timeout = user_ctx.timeout
-    url = f"{scheme}://{hostname}/config/v1/pools/"
-    headers = {"Authorization": f"{token.token_type} {token.token}",
-               "Accept": "application/json"}
-    result = requests.get(url, headers=headers, timeout=timeout)
-    if result.status_code != 200:
-        raise HdxCliException(f"Error getting pools.")
-    return json.loads(result.content)
 
 
 @find_in_disk_cache(cache_file=HDX_CONFIG_DIR / "cache/cache.bin",

--- a/src/hdx_cli/cli_interface/credential/commands.py
+++ b/src/hdx_cli/cli_interface/credential/commands.py
@@ -1,0 +1,144 @@
+import json
+import click
+
+from ..common.misc_operations import settings as command_settings
+from ..common.rest_operations import (
+    delete as command_delete,
+    list_ as command_list,
+    show as command_show
+)
+from ..common.undecorated_click_commands import basic_create_from_dict_body
+from ...library_api.common.generic_resource import access_resource
+from ...library_api.utility.decorators import report_error_and_exit, ensure_logged_in
+from ...library_api.common.context import ProfileUserContext
+from ...library_api.common.logging import get_logger
+
+logger = get_logger()
+
+
+@click.group(help="Credential-related operations")
+@click.option("--credential", "credential_name", metavar="CREDENTIAL_NAME", default=None,
+              help="Perform operation on the passed credential.")
+@click.pass_context
+@report_error_and_exit(exctype=Exception)
+@ensure_logged_in
+def credential(ctx: click.Context, credential_name: str):
+    user_profile = ctx.parent.obj['usercontext']
+    ProfileUserContext.update_context(user_profile, credentialname=credential_name)
+    org_id = user_profile.org_id
+    ctx.obj = {'resource_path': f'/config/v1/orgs/{org_id}/credentials/',
+               'usercontext': user_profile}
+
+
+@click.command(help="Create a new credential.")
+@click.argument("credential_name", metavar="CREDENTIAL_NAME")
+@click.argument("credential_type", metavar="CREDENTIAL_TYPE")
+@click.option("--description", required=False, help="Credential description.")
+@click.option(
+    "--details",
+    required=False,
+    default=None,
+    help="Credential details as a JSON string (e.g., '{\"key1\": \"value1\", \"key2\": \"value2\"}')."
+)
+@click.pass_context
+@report_error_and_exit(exctype=Exception)
+def create(ctx: click.Context,
+           credential_name: str,
+           credential_type: str,
+           description: str,
+           details: str
+           ):
+    """
+    Create a new credential by providing all parameters in a single command
+    or by providing them interactively.
+    """
+    profile = ctx.parent.obj.get("usercontext")
+    resource_path = ctx.parent.obj.get("resource_path")
+
+    # Retrieve available credential types
+    credential_types = access_resource(profile, [("credentials/types", None)])
+    if credential_type not in credential_types:
+        raise click.BadParameter(
+            f"'{credential_type}' is not a valid credential type. "
+            f"Consider using the 'list-types' command."
+        )
+
+    credential_type_info = credential_types[credential_type]
+    required_fields = credential_type_info.get("fields", {})
+
+    # Parse JSON string for --details if provided
+    if details:
+        try:
+            details = json.loads(details)
+        except json.JSONDecodeError:
+            raise click.BadParameter(
+                "Invalid format for --details. It should be a valid JSON string."
+            )
+    else:
+        details = {}
+
+    # Prompt for any missing required fields
+    for field, props in required_fields.items():
+        if field not in details:
+            attempts = 0
+            while attempts < 3:
+                logger.info(
+                    f"Enter value for '{field}' "
+                    f"({'Required' if props['required'] else 'Optional'}): [!i]"
+                )
+                value = input().strip()
+                if not value and props.get("required"):
+                    logger.info(f"'{field}' is required. Please provide a value.")
+                    attempts += 1
+                elif value:
+                    details[field] = value
+                    break
+                else:
+                    break
+            else:
+                logger.info("Too many failed attempts. Canceling operation.")
+                return
+
+    payload = {
+        "name": credential_name,
+        "description": description,
+        "type": credential_type,
+        "details": details
+    }
+    basic_create_from_dict_body(profile, resource_path, payload)
+    logger.info(f"Created credential {credential_name}")
+
+
+@click.command(help="List credential types.")
+@click.option("--cloud", "-c", "cloud", metavar="CLOUD", required=False, default=None,
+              help="Filter the credential types by a specific cloud.")
+@click.pass_context
+@report_error_and_exit(exctype=Exception)
+def list_types(ctx: click.Context, cloud: str):
+    profile = ctx.parent.obj["usercontext"]
+    credential_types = access_resource(profile, [("credentials/types", None)])
+
+    cloud = cloud.lower() if cloud else None
+    for cred, info_cred in credential_types.items():
+        cloud_name = info_cred.get("cloud", "unknown")
+        cloud_name = cloud_name.lower() if cloud_name else None
+        if cloud and cloud_name != cloud:
+            continue
+
+        logger.info(f"\nName: {cred}\nCloud: {cloud_name}")
+        parameters = info_cred.get("fields", {})
+        param_lines = [
+            f"  - {name} ({'required' if details.get('required') else 'optional'})"
+            for name, details in sorted(parameters.items(), key=lambda x: not x[1].get("required", False))
+        ]
+
+        if param_lines:
+            logger.info("\n".join(param_lines))
+
+
+credential.add_command(command_list)
+credential.add_command(create)
+credential.add_command(command_delete)
+credential.add_command(command_show)
+credential.add_command(command_settings)
+credential.add_command(list_types, name="list-types")

--- a/src/hdx_cli/library_api/common/context.py
+++ b/src/hdx_cli/library_api/common/context.py
@@ -44,6 +44,7 @@ class ProfileUserContext:
     poolname: Optional[str] = None
     useremail: Optional[str] = None
     rolename: Optional[str] = None
+    credentialname: Optional[str] = None
     scheme: str = 'https'
     timeout: int = DEFAULT_TIMEOUT
 

--- a/src/hdx_cli/main.py
+++ b/src/hdx_cli/main.py
@@ -18,6 +18,7 @@ from hdx_cli.cli_interface.integration import commands as integration_
 from hdx_cli.cli_interface.user import commands as user_
 from hdx_cli.cli_interface.role import commands as role_
 from hdx_cli.cli_interface.query_option import commands as query_option_
+from hdx_cli.cli_interface.credential import commands as credentials_
 from hdx_cli.cli_interface.check_health import commands as check_health_
 
 from hdx_cli.library_api.utility.decorators import report_error_and_exit
@@ -125,6 +126,7 @@ hdx_cli.add_command(integration_.integration)
 hdx_cli.add_command(user_.user)
 hdx_cli.add_command(role_.role)
 hdx_cli.add_command(query_option_.query_option)
+hdx_cli.add_command(credentials_.credential)
 hdx_cli.add_command(check_health_.check_health)
 hdx_cli.add_command(version)
 


### PR DESCRIPTION
This PR introduces a new credential command to manage credentials, including listing, creating, showing, deleting, and updating settings. 
Additionally, resource find methods have been refactored to simplify the code.

Usage examples:
`hdxcli credential list`
`hdxcli credential list-types [OPTIONS]`
`hdxcli credential create [OPTIONS] CREDENTIAL_NAME CREDENTIAL_TYPE`
`hdxcli credential --credential <credential_name> show [OPTIONS]`