### PR TITLE
Add Apache 2.0 License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,198 +1,144 @@
 [![](images/hdxcli.png)](https://github.com/hydrolix/hdx-cli)
 
 
-`hdxcli` is a command-line tool to work with hydrolix projects and tables
-interactively.
+`hdxcli` is the command-line tool to work with your Hydrolix clusters. It helps you manage resources like projects, tables, and Service Accounts. You can use it to automate tasks and include Hydrolix in your scripts and workflows.
 
-Common operations such as CRUD operations on projects/tables/transforms 
-and others  can be performed.
 
-# Hdx-cli installation
-
-You can install `hdxcli` from pip:
-
-```shell
-pip install hdxcli
-```
 ## System Requirements
-Python version `>= 3.10` is required.
+- Python: `>= 3.10`
 
-Make sure you have the correct Python version installed before proceeding 
-with the installation of `hdxcli`.
+Make sure you have the correct Python version installed.
 
-# Usage
-
-## Command-line tool organization
-
-The tool is organized, mostly with the general invocation form of:
-
+## Installation
+You can install hdxcli using pip:
 ```shell
-hdxcli <resource> [<subresource...] <verb> [<resource_name>]
+  pip install hdxcli
 ```
 
-Table and project resources have defaults that depend on the profile
-you are working with, so they can be omitted if you previously used 
-the `set` command.
+# First Steps: Initial Setup
+When you run your first `hdxcli` command (for example, `hdxcli project list`), if the CLI does not find a previous setup, it will guide you to create a 'default' connection profile. You will need to enter:
 
-For all other resources, you can use `--transform`, `--dictionary`, 
-`--source`, etc. Please see the command line help for more information.
+1. The **hostname** of your Hydrolix cluster (e.g., `mycluster.hydrolix.live`).
+2. If the connection will use **TLS (https)** (recommended).
 
-## Profiles
-`hdxcli` supports multiple profiles. You can use a default profile or
-use the `--profile` option to operate on a non-default profile.
+After setting up the profile, you will be asked to log in with your Hydrolix **username and password**. After a successful login, you can choose how the CLI will authenticate for future operations:
 
-When trying to invoke a command, if a login to the server is necessary, 
-a prompt will be shown and the token will be cached.
+- Continue using your user credentials.
+- Set up the CLI to use a **Service Account**. This is useful for longer sessions or for automated scripts.
 
-## Listing and showing profiles
-
-Listing profiles:
+You can also start this setup process yourself by running:
 ```shell
-hdxcli profile list
+  hdxcli init
 ```
+This command is good if you prefer to set up the CLI before running other commands.
 
-Showing default profile:
+## General Usage
+The main way to use commands is:
+
+`hdxcli [GLOBAL OPTIONS] RESOURCE [ACTION] [SPECIFIC ARGUMENTS...]`
+
+For example, `hdxcli project list` or `hdxcli table --project myproject create mytable`
+
+### Common Global Options (see hdxcli --help for all options):
+- `--profile PROFILE_NAME`: Use a specific connection profile.
+- `--username USERNAME`: Username for login (if needed).
+- `--password PASSWORD`: Password for login (if `--username` is used).
+- `--uri-scheme [http|https]</var>`: Choose the connection scheme (http or https).
+- `--timeout SECONDS`: Timeout for API requests.
+
+- ### Connection Profiles
+Profiles let you save settings for different Hydrolix clusters or users.
+
+- List profiles: `hdxcli profile list`
+- View details of the 'default' profile: `hdxcli profile show default`
+- Use a profile in a command: `hdxcli --profile my_other_profile project list`
+
+### Default Project and Table Context
+To make commands simpler, you can set a "current" or "default" project and table.
+
+- Set default project and table:
+    ```shell
+    hdxcli set <project-name> <table-name>
+    ```
+    Example: `hdxcli set weblogs access_logs`
+
+- After setting defaults, commands for tables or transforms will not need `--project` or `--table` options:
+    ```shell
+    hdxcli transform show my_transform # Will use project and table set by 'set' command
+    ```
+
+- Clear default project and table:
+    ```shell
+    hdxcli unset
+    ```
+  
+## Main Commands (Summary)
+`hdxcli` commands are grouped by the type of resource they manage. Use `hdxcli --help` to see all commands. Some of the main groups are:
+
+- `profile`: Manage your connection profiles.
+- `init`: Initialize `hdxcli` configuration.
+- `set` / `unset`: Set or clear the default project/table.
+- `project`: Create, list, delete, and manage projects.
+- `table`: Manage tables inside projects.
+- `transform`: Manage transforms.
+- `service-account`: Manage Service Accounts and their tokens.
+- `job`: Manage ingestion jobs.
+- (Other important groups like `dictionary`, `function`, `storage`, etc.)
+- `version`: Show the `hdxcli` version.
+
+To get help for a specific command group or command:
 ```shell
-hdxcli profile show
+    hdxcli project --help
+    hdxcli project create --help
 ```
 
-## Projects, tables and transforms
+### Usage Examples
+1. Set up the CLI, log in, and list projects:
+    ```shell
+    $ hdxcli init
+    # ... follow prompts to set up hostname, scheme, and login ...
+    # ... optionally, set up a Service Account ...
+    
+    $ hdxcli project list
+    project_a
+    project_b
+    ```
 
-The basic operations you can do with these resources are:
+2. Create a new project and then a table:
+    ```shell
+    $ hdxcli project create my_new_project
+    Created project 'my_new_project'
+    
+    $ hdxcli table --project my_new_project create my_new_table
+    Created table 'my_new_table'
+    ```
 
-- list them
-- create a new resource
-- delete an existing resource
-- modify an existing resource
-- show a resource in raw json format
-- show settings from a resource
-- write a setting
-- show a single setting
+3. Set a default context and show transform details:
+    ```shell
+    $ hdxcli set my_new_project my_new_table
+    Profile 'default' set project/table
+    
+    $ hdxcli transform show my_existing_transform
+    # ... (output of the transform) ...
+    ```
 
-## Working with transforms
+4. Show project information in indented JSON format:
+    ```shell
+    $ hdxcli project show my_new_project -i
+    {
+        "name": "my_new_project",
+        "org_id": "xxxx-xxxx-xxxx-xxxx",
+        ...
+    }
+    ```
+### Getting Help
+- For an overview of commands: `hdxcli --help`
+- For help on a specific resource or action: `hdxcli <resource> --help` or `hdxcli <resource> <action> --help`
+- For more in-depth information, check out the [official Hydrolix documentation](https://docs.hydrolix.io/docs/hdxcli).
 
-You can create and override transforms with the following commands.
+## License
 
-Create a transform:
-``` shell
-hdxcli transform create -f <transform-settings-file> <transform-name>
-```
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 
-Remember that a transform is applied to a table in a project, so whatever 
-you set with the command-line tool will be the target of your transform.
-
-
-If you want to override it, do:
-
-``` shell
-hdxcli --project <project-name> --table <table-name> transform create -f <transform-settings-file>.json <transform-name>
-```
-
-## Ingest
-### Batch Job
-Create a batch job:
-
-``` shell
-hdxcli job batch ingest <job-name> <job-settings>.json
-```
-
-`job-name` is the name of the job that will be displayed when listing batch 
-jobs. `job-settings` is the path to the file containing the specifications 
-required to create that ingestion (for more information on the required 
-specifications, see Hydrolix API Reference).
-
-In this case, the project, table, and transform are being omitted and the 
-CLI will use the default transform within the project and table previously 
-configured in the profile with the `--set` command. Otherwise, you can add 
-`--project <project-name>, --table <table-name> --transform <transform-name>`.
-
-This allows you to execute the command as follows:
-``` shell
-hdxcli --project <project-name>, --table <table-name> --transform <transform-name> job batch ingest <job-name> <job-settings>.json
-```
-
-# Commands
-
-- Profile
-  - *list*
-    - `hdxcli profile list`
-  - *add*
-    - `hdxcli profile add <profile-name>`
-  - *show*
-    - `hdxcli --profile <profile-name> profile show`
-- Set/Unset
-  - *set*
-    - `hdxcli set <project-name> <table-name>`
-  - *unset*
-    - `hdxcli unset`
-- Project
-  - *list*
-    - `hdxcli project list`
-  - *create*
-    - `hdxcli project create <project-name>`
-  - *delete*
-    - `hdxcli project delete <project-name>`
-  - *activity*
-    - `hdxcli --project <project-name> project activity`
-  - *stats*
-    - `hdxcli --project <project-name> project stats`
-  - *show*
-    - `hdxcli --project <project-name> project show`
-  - *settings*
-    - `hdxcli --project <project-name> project settings`
-    - `hdxcli --project <project-name> project settings <setting-name>`
-    - `hdxcli --project <project-name> project settings <setting-name> <new-value>`
-- Table
-- Transform
-- Job
-- Purgejobs
-- Sources
-- Dictionary
-- Dictionary Files
-- Function
-- Storage
-- Integration
-- Migrate
-- Version
-
-# FAQ: Common operations
-
-## Showing help 
-
-In order to see what you can do with the tool:
-
-``` shell
-hdxcli --help
-```
-
-Check which commands are available for each resource by typing:
-``` shell
-hdxcli [<resource>...] [<verb>] --help
-```
-
-## Performing operations against another server
-
-If you want to use `hdxcli` against another server, use `--profile` option:
-``` shell
-hdxcli --profile <profile-name> project list
-```
-
-## Obtain indented resource information
-
-When you use the verb `show` on any resource, the output looks like this:
-``` shell
-hdxcli --project <project-name> project show
-{"name": "project-name", "org": "org-uuid", "description": "description", "uuid": "uuid", ...}
-```
-
-If you need to have an indented json version, just add `-i`, `--indent int`:
-``` shell
-hdxcli --project <project-name> project show -i 4
-{
-    "name": "project-name", 
-    "org": "org-uuid", 
-    "description": "description", 
-    "uuid": "uuid", 
-    ...,
-}
-```
+This project is licensed under the terms of the **Apache License 2.0**.
+You can find a copy of the license in the [LICENSE](LICENSE) file included in this repository.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ name = "hdxcli"
 version = "1.0.79"
 description = "Hydrolix command line utility to do CRUD operations on projects, tables, transforms and other resources in Hydrolix clusters"
 authors = ["German Diago Gomez <german@hydrolix.io>", "Agustin Actis <agustin@hydrolix.io>"]
-license = "MIT license"
+license = "Apache-2.0"
 keywords = ["database", "bigdata", "hydrolix"]
 classifiers = ["Development Status :: 3 - Alpha",
                "Topic :: Database",


### PR DESCRIPTION
This PR introduces the Apache 2.0 license to the project.

**Key changes:**

* Added the `LICENSE` file containing the full Apache License, Version 2.0 text.
* Updated the `pyproject.toml` file.
* Modified the `README.md` file to include information about the project's license + general updates.

No functional changes are introduced.
