### PR TITLE
[HDX-5869] Add new 'logs' command

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -201,6 +201,104 @@ files = [
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
+name = "clickhouse-connect"
+version = "0.9.1"
+description = "ClickHouse Database Core Driver for Python, Pandas, and Superset"
+optional = false
+python-versions = "~=3.8"
+groups = ["main"]
+files = [
+    {file = "clickhouse_connect-0.9.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:8ca6cfcc64933d994de13ad55f1184298fe79eda908590800e2ee980ac544293"},
+    {file = "clickhouse_connect-0.9.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7dcfc3e953bd3b05deda6dab19f8714e950946e37d92c510b7c6f0c971b36243"},
+    {file = "clickhouse_connect-0.9.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f96f7e178beda3decfaa10787a127ecf546afdaa563894e2b580acb9069bbf82"},
+    {file = "clickhouse_connect-0.9.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ed3bb9ff957a6dee1fbae67c63b78f165979519e14f2e5ba273cf0a64b06944a"},
+    {file = "clickhouse_connect-0.9.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:39a34722100675a76a2af2fbac2e6a14a6bbc7e90c653730a83d5fb3d8e734e2"},
+    {file = "clickhouse_connect-0.9.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:904341d99bacf1e2e829f34ed24423fbc4218ebef39325bc8746cd3df8ba5b8c"},
+    {file = "clickhouse_connect-0.9.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:5744baa9f7731d5709e241d375742c8275659f4ede9767447a8232ca6be51c9f"},
+    {file = "clickhouse_connect-0.9.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:2a0eefdcf78a81f650e6a6fd2604b8fe04fac6066b9d5e3802c36c1d9274fec2"},
+    {file = "clickhouse_connect-0.9.1-cp310-cp310-win32.whl", hash = "sha256:bcb893c3366b8b0181e0e7313e70cacc27f5fd17f177ce926322fc538d0ec489"},
+    {file = "clickhouse_connect-0.9.1-cp310-cp310-win_amd64.whl", hash = "sha256:a8a101df6c8b23a1ea44e9d390f7e4cbfa3489d58c38488db3e5af493346c2d9"},
+    {file = "clickhouse_connect-0.9.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:dec937f78763608e64132ca3d128d91d98b126a2b8f586361c27ee827cf0b506"},
+    {file = "clickhouse_connect-0.9.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e57c388bc6dde0c5c69b94d2a7ea2f2702946b8392ce654e70c86eb4e9fc6bfa"},
+    {file = "clickhouse_connect-0.9.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4ceaa2c36e83cab507a5e165b08f071558731015ac52a5976387800cb6772006"},
+    {file = "clickhouse_connect-0.9.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f2664d165a6c6cb08ad4f6759a9f4fedb2033325c9c116b0500d96370e97767"},
+    {file = "clickhouse_connect-0.9.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:abd717f3a8dbd25faedc9fdb42359ef8ae2780389407a9b371827352f10cd030"},
+    {file = "clickhouse_connect-0.9.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:3e412301de4e6a58b2272cd543d23301f93f1800c6529c11b90f7222404fcf7c"},
+    {file = "clickhouse_connect-0.9.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:f08437e8b2fd4149f0d14d7d011f35e8c943551f20977ecf9cd065e35e8fbd3f"},
+    {file = "clickhouse_connect-0.9.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5562b2417908db824714161ab1bbbb97713a9236cb4707c63c1ac518f9f3a63d"},
+    {file = "clickhouse_connect-0.9.1-cp311-cp311-win32.whl", hash = "sha256:49c479a272b6f663ff1328a998354706837352c7eec70a7ecf663eb5d2991b67"},
+    {file = "clickhouse_connect-0.9.1-cp311-cp311-win_amd64.whl", hash = "sha256:5cd9149ec7bcdef783ac850ca9494f5c0ec499b205b97431f55bf04ad0078cd9"},
+    {file = "clickhouse_connect-0.9.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:de212078f031170063f2e7ecee5276716685fc5a8e8a53797747e2d5a75f1474"},
+    {file = "clickhouse_connect-0.9.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c55c9c04b9a32bfc8bb278e09fb6abe3822153da49e734ca4f02c57d73999097"},
+    {file = "clickhouse_connect-0.9.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b9841d37b30b9d14fca5d8e5ba6b78006ea96b1303272e52d2e738f74c090325"},
+    {file = "clickhouse_connect-0.9.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:96979801f81039640a6d8131330882d7cebf333c7c3668b43a2d7647f59546df"},
+    {file = "clickhouse_connect-0.9.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6834679b1ad14931b9b068f405f5b6b34ca0c038d566c7a05362aa31fd61f95c"},
+    {file = "clickhouse_connect-0.9.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a7ca849d788b57d88e57aa71e877ee5fd5d91899610500118f2a5e27e02a0ae5"},
+    {file = "clickhouse_connect-0.9.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5b7e6d2a28b2b7b977d200f8e55ae96a40f742f29b0d2aad9b86b04a78256aff"},
+    {file = "clickhouse_connect-0.9.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:dfc744ae1316c46db8bd7178caefbcdd52106649a959965b88e14563450b1c7c"},
+    {file = "clickhouse_connect-0.9.1-cp312-cp312-win32.whl", hash = "sha256:00b930248dd10c51d538eadf0313e106ddc8bb3e9bb6b6beacbf19c021ad019b"},
+    {file = "clickhouse_connect-0.9.1-cp312-cp312-win_amd64.whl", hash = "sha256:892680a0a9ae4b3580f2189e966e21d82e370ff42314c915ed2d83855d333571"},
+    {file = "clickhouse_connect-0.9.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a5a18314a460d3273f88633269ddfce14896810bba51b715445fb7b5cfeb2f68"},
+    {file = "clickhouse_connect-0.9.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6475c78494f0049a0a690f2c931ae00d0bd9a7f6ba045d97a8b974e42a328c27"},
+    {file = "clickhouse_connect-0.9.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1d61d0cb67a2bfd6427fe90f05fff4cedaaa87e8f455a943366e9c0e8a1f2c89"},
+    {file = "clickhouse_connect-0.9.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77cfa2aa01dd0d6d629434aeb05385432edf27dc2f387250123c724c529191ba"},
+    {file = "clickhouse_connect-0.9.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:352e5616b396ac8aa4698e6e3dc236de4a1a6ac18e27e3cce5b763bf160aad24"},
+    {file = "clickhouse_connect-0.9.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7cb05aa66f7c0e54d303f15c94410f32b7ce478be555698bbbec0dbeece3f075"},
+    {file = "clickhouse_connect-0.9.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:3b644816c42ec6f62a0b6ff7ac01771bce9ac9d73dda3c1d988bbd2c92fdab99"},
+    {file = "clickhouse_connect-0.9.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:daae9d762ae68548c9e9c27652afcb19f1a4d7ea6064b293b118f3a03b0cf5de"},
+    {file = "clickhouse_connect-0.9.1-cp313-cp313-win32.whl", hash = "sha256:52a7305067360c0e8e218220317b4dadbea9bcc488b789ce35fe6d67837c09cf"},
+    {file = "clickhouse_connect-0.9.1-cp313-cp313-win_amd64.whl", hash = "sha256:79e5fac1821b015c024364d3f6779e408674f4ef14110d4330df6154af779f39"},
+    {file = "clickhouse_connect-0.9.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:be14d2ffbe279e40e8810b7d1e03402050db444173fb8e2eec29e9484fcdc66d"},
+    {file = "clickhouse_connect-0.9.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:310d0fedcb2ed705d3c28fcbaafee31430d302a70064a8ed8a10d70714da833e"},
+    {file = "clickhouse_connect-0.9.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8790520861720609a40d6902afd3e5ee883a8bfa27351607ad2c2a882b99aec7"},
+    {file = "clickhouse_connect-0.9.1-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:e860b5e910e1caa70c6bff68c03b2c3272cfa2137708220a0bfa1463d78584be"},
+    {file = "clickhouse_connect-0.9.1-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:80332c6d681782bd0d27078fc056a7a8438d2fede691aeeb66d7b020ee9f10fb"},
+    {file = "clickhouse_connect-0.9.1-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:fb38b22dc7c51d774d051766aca725106d75173b17d5c417944841ae1615ae6f"},
+    {file = "clickhouse_connect-0.9.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:36ddafec221ad02dc93f646672b985faa10b9f207683f566a3455248310702bc"},
+    {file = "clickhouse_connect-0.9.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c71c3d7b542988f21bd9741f9a7327b2b1516de77cc2b0bea5b50f3bb8a8aefb"},
+    {file = "clickhouse_connect-0.9.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9c2e981abb1696d797ef37c59f5c5c9e67f514de251982f8b424c049b30719ae"},
+    {file = "clickhouse_connect-0.9.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f665b00dd707f88906a5d2ccb3be2d047aff0e164592433ff45de4fff9164086"},
+    {file = "clickhouse_connect-0.9.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a430b5ff46fad59193250e04f4be57a440772c1febd5f2b1b91891a7b73cebd4"},
+    {file = "clickhouse_connect-0.9.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:846810f3f93a196b8c708970f8b0345c351a343b411ebb2d5dcb1e2c4bee7adb"},
+    {file = "clickhouse_connect-0.9.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:4de9f97aee1594c5876116fba6318a187a1344217007fc27c1c6e3d56a070f6e"},
+    {file = "clickhouse_connect-0.9.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:2a3145880cca3238c9bd43c0cf9a6ffd712592ff4e7209e714e42bb815aa0670"},
+    {file = "clickhouse_connect-0.9.1-cp39-cp39-win32.whl", hash = "sha256:2070f79b490dcdec149cd93609f33dd0f11fbe2095225c51a0ba121be894a532"},
+    {file = "clickhouse_connect-0.9.1-cp39-cp39-win_amd64.whl", hash = "sha256:468ee1cdc7a83d12c9d6eb7c3122bdca8cc475a8043873b05d567cbc33b6844f"},
+    {file = "clickhouse_connect-0.9.1-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:f23901e739cb4d17852434a58d901fd1a682ee2a3cbac0b9760a7506b669e3ea"},
+    {file = "clickhouse_connect-0.9.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:b4c74886bb25c55bd33b96ea81291568ec01a4c6bededa8ea08ae08d5fa701ef"},
+    {file = "clickhouse_connect-0.9.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:798742be22e95857c3307fb77437ad611517d4661b72eaaa1328607391da748d"},
+    {file = "clickhouse_connect-0.9.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d51726902c63a2d1fc081d528fba5070f6a81c6fc110d239f1137d00c0a5e405"},
+    {file = "clickhouse_connect-0.9.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dcf7c80181763d932270319d2ec019fd6954f35fa8ec60f9a9b9f54ed5aa08d2"},
+    {file = "clickhouse_connect-0.9.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:ad8cd3ba348306c45f222007cf4c0b03b21570fd71e4f9c6d3da2d5a60deff6c"},
+    {file = "clickhouse_connect-0.9.1-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:3d9ca7b8079731d7be5f99c12c26e3ef6abeeaf344fbbe9c0929bfb39ed9306d"},
+    {file = "clickhouse_connect-0.9.1-pp38-pypy38_pp73-macosx_11_0_arm64.whl", hash = "sha256:1b89b4efc3ad1d4375e81235ce311e77590db85c7b9f8195fd65734c91e44a1b"},
+    {file = "clickhouse_connect-0.9.1-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:b51fad47cd2c2f535b69c14604dbf80eccccace77c2b4a3ccb9dfcb46edbd9a4"},
+    {file = "clickhouse_connect-0.9.1-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:139957b222343fc1664e6e4ad61c35d3e3c890e3942c3b9dce52b0b8ce411624"},
+    {file = "clickhouse_connect-0.9.1-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:6d5a3c9d084828556a02e718ffe6a085f4dc6e1ae1353f3585c29bc281ef35c4"},
+    {file = "clickhouse_connect-0.9.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6c9fe8992cfc559ce95ecfdfa477d5e9a03537634172fc1bac824cac5a25c683"},
+    {file = "clickhouse_connect-0.9.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d67bd920e572ec468253ec46c4e43544736ebd1cb86c1cf02bfc2fee24269c43"},
+    {file = "clickhouse_connect-0.9.1-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ca606c3b544fad4ce36e688ba6d171a6e6bad7aff36ddbb54db9d8f1ff578243"},
+    {file = "clickhouse_connect-0.9.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:7efa665f00e409590a1351c22127f01ba41d5beac84aab91dc7d339599037247"},
+    {file = "clickhouse_connect-0.9.1.tar.gz", hash = "sha256:fde47679b0b7213042e4ddd47b1cd6f7d128258988087bfd5c174e26b4010d12"},
+]
+
+[package.dependencies]
+certifi = "*"
+lz4 = "*"
+pytz = "*"
+urllib3 = ">=1.26"
+zstandard = "*"
+
+[package.extras]
+arrow = ["pyarrow"]
+numpy = ["numpy"]
+orjson = ["orjson"]
+pandas = ["pandas"]
+polars = ["polars (>=1.0)"]
+sqlalchemy = ["sqlalchemy (>=1.4.40,<3.0)"]
+tzlocal = ["tzlocal (>=4.0)"]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
@@ -379,6 +477,62 @@ benchmark = ["pytest", "pytest-benchmark"]
 dev = ["black", "flake8", "isort", "pre-commit", "pyproject-flake8"]
 doc = ["myst-parser", "sphinx", "sphinx-book-theme"]
 test = ["coverage", "pytest", "pytest-cov"]
+
+[[package]]
+name = "lz4"
+version = "4.4.4"
+description = "LZ4 Bindings for Python"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "lz4-4.4.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f170abb8416c4efca48e76cac2c86c3185efdf841aecbe5c190121c42828ced0"},
+    {file = "lz4-4.4.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d33a5105cd96ebd32c3e78d7ece6123a9d2fb7c18b84dec61f27837d9e0c496c"},
+    {file = "lz4-4.4.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:30ebbc5b76b4f0018988825a7e9ce153be4f0d4eba34e6c1f2fcded120573e88"},
+    {file = "lz4-4.4.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc64d6dfa7a89397529b22638939e70d85eaedc1bd68e30a29c78bfb65d4f715"},
+    {file = "lz4-4.4.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a355223a284f42a723c120ce68827de66d5cb872a38732b3d5abbf544fa2fe26"},
+    {file = "lz4-4.4.4-cp310-cp310-win32.whl", hash = "sha256:b28228197775b7b5096898851d59ef43ccaf151136f81d9c436bc9ba560bc2ba"},
+    {file = "lz4-4.4.4-cp310-cp310-win_amd64.whl", hash = "sha256:45e7c954546de4f85d895aa735989d77f87dd649f503ce1c8a71a151b092ed36"},
+    {file = "lz4-4.4.4-cp310-cp310-win_arm64.whl", hash = "sha256:e3fc90f766401684740978cd781d73b9685bd81b5dbf7257542ef9de4612e4d2"},
+    {file = "lz4-4.4.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ddfc7194cd206496c445e9e5b0c47f970ce982c725c87bd22de028884125b68f"},
+    {file = "lz4-4.4.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:714f9298c86f8e7278f1c6af23e509044782fa8220eb0260f8f8f1632f820550"},
+    {file = "lz4-4.4.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a8474c91de47733856c6686df3c4aca33753741da7e757979369c2c0d32918ba"},
+    {file = "lz4-4.4.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:80dd27d7d680ea02c261c226acf1d41de2fd77af4fb2da62b278a9376e380de0"},
+    {file = "lz4-4.4.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9b7d6dddfd01b49aedb940fdcaf32f41dc58c926ba35f4e31866aeec2f32f4f4"},
+    {file = "lz4-4.4.4-cp311-cp311-win32.whl", hash = "sha256:4134b9fd70ac41954c080b772816bb1afe0c8354ee993015a83430031d686a4c"},
+    {file = "lz4-4.4.4-cp311-cp311-win_amd64.whl", hash = "sha256:f5024d3ca2383470f7c4ef4d0ed8eabad0b22b23eeefde1c192cf1a38d5e9f78"},
+    {file = "lz4-4.4.4-cp311-cp311-win_arm64.whl", hash = "sha256:6ea715bb3357ea1665f77874cf8f55385ff112553db06f3742d3cdcec08633f7"},
+    {file = "lz4-4.4.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:23ae267494fdd80f0d2a131beff890cf857f1b812ee72dbb96c3204aab725553"},
+    {file = "lz4-4.4.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fff9f3a1ed63d45cb6514bfb8293005dc4141341ce3500abdfeb76124c0b9b2e"},
+    {file = "lz4-4.4.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1ea7f07329f85a8eda4d8cf937b87f27f0ac392c6400f18bea2c667c8b7f8ecc"},
+    {file = "lz4-4.4.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8ccab8f7f7b82f9fa9fc3b0ba584d353bd5aa818d5821d77d5b9447faad2aaad"},
+    {file = "lz4-4.4.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e43e9d48b2daf80e486213128b0763deed35bbb7a59b66d1681e205e1702d735"},
+    {file = "lz4-4.4.4-cp312-cp312-win32.whl", hash = "sha256:33e01e18e4561b0381b2c33d58e77ceee850a5067f0ece945064cbaac2176962"},
+    {file = "lz4-4.4.4-cp312-cp312-win_amd64.whl", hash = "sha256:d21d1a2892a2dcc193163dd13eaadabb2c1b803807a5117d8f8588b22eaf9f12"},
+    {file = "lz4-4.4.4-cp312-cp312-win_arm64.whl", hash = "sha256:2f4f2965c98ab254feddf6b5072854a6935adab7bc81412ec4fe238f07b85f62"},
+    {file = "lz4-4.4.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ed6eb9f8deaf25ee4f6fad9625d0955183fdc90c52b6f79a76b7f209af1b6e54"},
+    {file = "lz4-4.4.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:18ae4fe3bafb344dbd09f976d45cbf49c05c34416f2462828f9572c1fa6d5af7"},
+    {file = "lz4-4.4.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:57fd20c5fc1a49d1bbd170836fccf9a338847e73664f8e313dce6ac91b8c1e02"},
+    {file = "lz4-4.4.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e9cb387c33f014dae4db8cb4ba789c8d2a0a6d045ddff6be13f6c8d9def1d2a6"},
+    {file = "lz4-4.4.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d0be9f68240231e1e44118a4ebfecd8a5d4184f0bdf5c591c98dd6ade9720afd"},
+    {file = "lz4-4.4.4-cp313-cp313-win32.whl", hash = "sha256:e9ec5d45ea43684f87c316542af061ef5febc6a6b322928f059ce1fb289c298a"},
+    {file = "lz4-4.4.4-cp313-cp313-win_amd64.whl", hash = "sha256:a760a175b46325b2bb33b1f2bbfb8aa21b48e1b9653e29c10b6834f9bb44ead4"},
+    {file = "lz4-4.4.4-cp313-cp313-win_arm64.whl", hash = "sha256:f4c21648d81e0dda38b4720dccc9006ae33b0e9e7ffe88af6bf7d4ec124e2fba"},
+    {file = "lz4-4.4.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:bd1add57b6fe1f96bed2d529de085e9378a3ac04b86f116d10506f85b68e97fc"},
+    {file = "lz4-4.4.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:900912e8a7cf74b4a2bea18a3594ae0bf1138f99919c20017167b6e05f760aa4"},
+    {file = "lz4-4.4.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:017f8d269a739405a59d68a4d63d23a8df23e3bb2c70aa069b7563af08dfdffb"},
+    {file = "lz4-4.4.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dac522788296a9a02a39f620970dea86c38e141e21e51238f1b5e9fa629f8e69"},
+    {file = "lz4-4.4.4-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6b56aa9eef830bf6443acd8c4e18b208a8993dc32e0d6ef4263ecfa6afb3f599"},
+    {file = "lz4-4.4.4-cp39-cp39-win32.whl", hash = "sha256:585b42eb37ab16a278c3a917ec23b2beef175aa669f4120142b97aebf90ef775"},
+    {file = "lz4-4.4.4-cp39-cp39-win_amd64.whl", hash = "sha256:4ab1537bd3b3bfbafd3c8847e06827129794488304f21945fc2f5b669649d94f"},
+    {file = "lz4-4.4.4-cp39-cp39-win_arm64.whl", hash = "sha256:38730927ad51beb42ab8dbc5555270bfbe86167ba734265f88bbd799fced1004"},
+    {file = "lz4-4.4.4.tar.gz", hash = "sha256:070fd0627ec4393011251a094e08ed9fdcc78cb4e7ab28f507638eee4e39abda"},
+]
+
+[package.extras]
+docs = ["sphinx (>=1.6.0)", "sphinx_bootstrap_theme"]
+flake8 = ["flake8"]
+tests = ["psutil", "pytest (!=3.3.0)", "pytest-cov"]
 
 [[package]]
 name = "markdown-it-py"
@@ -772,6 +926,18 @@ tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytz"
+version = "2025.2"
+description = "World timezone definitions, modern and historical"
+optional = false
+python-versions = "*"
+groups = ["main"]
+files = [
+    {file = "pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00"},
+    {file = "pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3"},
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.2"
 description = "YAML parser and emitter for Python"
@@ -1102,7 +1268,119 @@ files = [
     {file = "wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5"},
 ]
 
+[[package]]
+name = "zstandard"
+version = "0.25.0"
+description = "Zstandard bindings for Python"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "zstandard-0.25.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e59fdc271772f6686e01e1b3b74537259800f57e24280be3f29c8a0deb1904dd"},
+    {file = "zstandard-0.25.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4d441506e9b372386a5271c64125f72d5df6d2a8e8a2a45a0ae09b03cb781ef7"},
+    {file = "zstandard-0.25.0-cp310-cp310-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:ab85470ab54c2cb96e176f40342d9ed41e58ca5733be6a893b730e7af9c40550"},
+    {file = "zstandard-0.25.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e05ab82ea7753354bb054b92e2f288afb750e6b439ff6ca78af52939ebbc476d"},
+    {file = "zstandard-0.25.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:78228d8a6a1c177a96b94f7e2e8d012c55f9c760761980da16ae7546a15a8e9b"},
+    {file = "zstandard-0.25.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:2b6bd67528ee8b5c5f10255735abc21aa106931f0dbaf297c7be0c886353c3d0"},
+    {file = "zstandard-0.25.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4b6d83057e713ff235a12e73916b6d356e3084fd3d14ced499d84240f3eecee0"},
+    {file = "zstandard-0.25.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:9174f4ed06f790a6869b41cba05b43eeb9a35f8993c4422ab853b705e8112bbd"},
+    {file = "zstandard-0.25.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:25f8f3cd45087d089aef5ba3848cd9efe3ad41163d3400862fb42f81a3a46701"},
+    {file = "zstandard-0.25.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:3756b3e9da9b83da1796f8809dd57cb024f838b9eeafde28f3cb472012797ac1"},
+    {file = "zstandard-0.25.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:81dad8d145d8fd981b2962b686b2241d3a1ea07733e76a2f15435dfb7fb60150"},
+    {file = "zstandard-0.25.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:a5a419712cf88862a45a23def0ae063686db3d324cec7edbe40509d1a79a0aab"},
+    {file = "zstandard-0.25.0-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:e7360eae90809efd19b886e59a09dad07da4ca9ba096752e61a2e03c8aca188e"},
+    {file = "zstandard-0.25.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:75ffc32a569fb049499e63ce68c743155477610532da1eb38e7f24bf7cd29e74"},
+    {file = "zstandard-0.25.0-cp310-cp310-win32.whl", hash = "sha256:106281ae350e494f4ac8a80470e66d1fe27e497052c8d9c3b95dc4cf1ade81aa"},
+    {file = "zstandard-0.25.0-cp310-cp310-win_amd64.whl", hash = "sha256:ea9d54cc3d8064260114a0bbf3479fc4a98b21dffc89b3459edd506b69262f6e"},
+    {file = "zstandard-0.25.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:933b65d7680ea337180733cf9e87293cc5500cc0eb3fc8769f4d3c88d724ec5c"},
+    {file = "zstandard-0.25.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a3f79487c687b1fc69f19e487cd949bf3aae653d181dfb5fde3bf6d18894706f"},
+    {file = "zstandard-0.25.0-cp311-cp311-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:0bbc9a0c65ce0eea3c34a691e3c4b6889f5f3909ba4822ab385fab9057099431"},
+    {file = "zstandard-0.25.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:01582723b3ccd6939ab7b3a78622c573799d5d8737b534b86d0e06ac18dbde4a"},
+    {file = "zstandard-0.25.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5f1ad7bf88535edcf30038f6919abe087f606f62c00a87d7e33e7fc57cb69fcc"},
+    {file = "zstandard-0.25.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:06acb75eebeedb77b69048031282737717a63e71e4ae3f77cc0c3b9508320df6"},
+    {file = "zstandard-0.25.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9300d02ea7c6506f00e627e287e0492a5eb0371ec1670ae852fefffa6164b072"},
+    {file = "zstandard-0.25.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:bfd06b1c5584b657a2892a6014c2f4c20e0db0208c159148fa78c65f7e0b0277"},
+    {file = "zstandard-0.25.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:f373da2c1757bb7f1acaf09369cdc1d51d84131e50d5fa9863982fd626466313"},
+    {file = "zstandard-0.25.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6c0e5a65158a7946e7a7affa6418878ef97ab66636f13353b8502d7ea03c8097"},
+    {file = "zstandard-0.25.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:c8e167d5adf59476fa3e37bee730890e389410c354771a62e3c076c86f9f7778"},
+    {file = "zstandard-0.25.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:98750a309eb2f020da61e727de7d7ba3c57c97cf6213f6f6277bb7fb42a8e065"},
+    {file = "zstandard-0.25.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:22a086cff1b6ceca18a8dd6096ec631e430e93a8e70a9ca5efa7561a00f826fa"},
+    {file = "zstandard-0.25.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:72d35d7aa0bba323965da807a462b0966c91608ef3a48ba761678cb20ce5d8b7"},
+    {file = "zstandard-0.25.0-cp311-cp311-win32.whl", hash = "sha256:f5aeea11ded7320a84dcdd62a3d95b5186834224a9e55b92ccae35d21a8b63d4"},
+    {file = "zstandard-0.25.0-cp311-cp311-win_amd64.whl", hash = "sha256:daab68faadb847063d0c56f361a289c4f268706b598afbf9ad113cbe5c38b6b2"},
+    {file = "zstandard-0.25.0-cp311-cp311-win_arm64.whl", hash = "sha256:22a06c5df3751bb7dc67406f5374734ccee8ed37fc5981bf1ad7041831fa1137"},
+    {file = "zstandard-0.25.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7b3c3a3ab9daa3eed242d6ecceead93aebbb8f5f84318d82cee643e019c4b73b"},
+    {file = "zstandard-0.25.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:913cbd31a400febff93b564a23e17c3ed2d56c064006f54efec210d586171c00"},
+    {file = "zstandard-0.25.0-cp312-cp312-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:011d388c76b11a0c165374ce660ce2c8efa8e5d87f34996aa80f9c0816698b64"},
+    {file = "zstandard-0.25.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dffecc361d079bb48d7caef5d673c88c8988d3d33fb74ab95b7ee6da42652ea"},
+    {file = "zstandard-0.25.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7149623bba7fdf7e7f24312953bcf73cae103db8cae49f8154dd1eadc8a29ecb"},
+    {file = "zstandard-0.25.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6a573a35693e03cf1d67799fd01b50ff578515a8aeadd4595d2a7fa9f3ec002a"},
+    {file = "zstandard-0.25.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5a56ba0db2d244117ed744dfa8f6f5b366e14148e00de44723413b2f3938a902"},
+    {file = "zstandard-0.25.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:10ef2a79ab8e2974e2075fb984e5b9806c64134810fac21576f0668e7ea19f8f"},
+    {file = "zstandard-0.25.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aaf21ba8fb76d102b696781bddaa0954b782536446083ae3fdaa6f16b25a1c4b"},
+    {file = "zstandard-0.25.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1869da9571d5e94a85a5e8d57e4e8807b175c9e4a6294e3b66fa4efb074d90f6"},
+    {file = "zstandard-0.25.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:809c5bcb2c67cd0ed81e9229d227d4ca28f82d0f778fc5fea624a9def3963f91"},
+    {file = "zstandard-0.25.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f27662e4f7dbf9f9c12391cb37b4c4c3cb90ffbd3b1fb9284dadbbb8935fa708"},
+    {file = "zstandard-0.25.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:99c0c846e6e61718715a3c9437ccc625de26593fea60189567f0118dc9db7512"},
+    {file = "zstandard-0.25.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:474d2596a2dbc241a556e965fb76002c1ce655445e4e3bf38e5477d413165ffa"},
+    {file = "zstandard-0.25.0-cp312-cp312-win32.whl", hash = "sha256:23ebc8f17a03133b4426bcc04aabd68f8236eb78c3760f12783385171b0fd8bd"},
+    {file = "zstandard-0.25.0-cp312-cp312-win_amd64.whl", hash = "sha256:ffef5a74088f1e09947aecf91011136665152e0b4b359c42be3373897fb39b01"},
+    {file = "zstandard-0.25.0-cp312-cp312-win_arm64.whl", hash = "sha256:181eb40e0b6a29b3cd2849f825e0fa34397f649170673d385f3598ae17cca2e9"},
+    {file = "zstandard-0.25.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ec996f12524f88e151c339688c3897194821d7f03081ab35d31d1e12ec975e94"},
+    {file = "zstandard-0.25.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a1a4ae2dec3993a32247995bdfe367fc3266da832d82f8438c8570f989753de1"},
+    {file = "zstandard-0.25.0-cp313-cp313-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:e96594a5537722fdfb79951672a2a63aec5ebfb823e7560586f7484819f2a08f"},
+    {file = "zstandard-0.25.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:bfc4e20784722098822e3eee42b8e576b379ed72cca4a7cb856ae733e62192ea"},
+    {file = "zstandard-0.25.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:457ed498fc58cdc12fc48f7950e02740d4f7ae9493dd4ab2168a47c93c31298e"},
+    {file = "zstandard-0.25.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:fd7a5004eb1980d3cefe26b2685bcb0b17989901a70a1040d1ac86f1d898c551"},
+    {file = "zstandard-0.25.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8e735494da3db08694d26480f1493ad2cf86e99bdd53e8e9771b2752a5c0246a"},
+    {file = "zstandard-0.25.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3a39c94ad7866160a4a46d772e43311a743c316942037671beb264e395bdd611"},
+    {file = "zstandard-0.25.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:172de1f06947577d3a3005416977cce6168f2261284c02080e7ad0185faeced3"},
+    {file = "zstandard-0.25.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3c83b0188c852a47cd13ef3bf9209fb0a77fa5374958b8c53aaa699398c6bd7b"},
+    {file = "zstandard-0.25.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:1673b7199bbe763365b81a4f3252b8e80f44c9e323fc42940dc8843bfeaf9851"},
+    {file = "zstandard-0.25.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:0be7622c37c183406f3dbf0cba104118eb16a4ea7359eeb5752f0794882fc250"},
+    {file = "zstandard-0.25.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:5f5e4c2a23ca271c218ac025bd7d635597048b366d6f31f420aaeb715239fc98"},
+    {file = "zstandard-0.25.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4f187a0bb61b35119d1926aee039524d1f93aaf38a9916b8c4b78ac8514a0aaf"},
+    {file = "zstandard-0.25.0-cp313-cp313-win32.whl", hash = "sha256:7030defa83eef3e51ff26f0b7bfb229f0204b66fe18e04359ce3474ac33cbc09"},
+    {file = "zstandard-0.25.0-cp313-cp313-win_amd64.whl", hash = "sha256:1f830a0dac88719af0ae43b8b2d6aef487d437036468ef3c2ea59c51f9d55fd5"},
+    {file = "zstandard-0.25.0-cp313-cp313-win_arm64.whl", hash = "sha256:85304a43f4d513f5464ceb938aa02c1e78c2943b29f44a750b48b25ac999a049"},
+    {file = "zstandard-0.25.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e29f0cf06974c899b2c188ef7f783607dbef36da4c242eb6c82dcd8b512855e3"},
+    {file = "zstandard-0.25.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:05df5136bc5a011f33cd25bc9f506e7426c0c9b3f9954f056831ce68f3b6689f"},
+    {file = "zstandard-0.25.0-cp314-cp314-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:f604efd28f239cc21b3adb53eb061e2a205dc164be408e553b41ba2ffe0ca15c"},
+    {file = "zstandard-0.25.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223415140608d0f0da010499eaa8ccdb9af210a543fac54bce15babbcfc78439"},
+    {file = "zstandard-0.25.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2e54296a283f3ab5a26fc9b8b5d4978ea0532f37b231644f367aa588930aa043"},
+    {file = "zstandard-0.25.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ca54090275939dc8ec5dea2d2afb400e0f83444b2fc24e07df7fdef677110859"},
+    {file = "zstandard-0.25.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e09bb6252b6476d8d56100e8147b803befa9a12cea144bbe629dd508800d1ad0"},
+    {file = "zstandard-0.25.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a9ec8c642d1ec73287ae3e726792dd86c96f5681eb8df274a757bf62b750eae7"},
+    {file = "zstandard-0.25.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a4089a10e598eae6393756b036e0f419e8c1d60f44a831520f9af41c14216cf2"},
+    {file = "zstandard-0.25.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:f67e8f1a324a900e75b5e28ffb152bcac9fbed1cc7b43f99cd90f395c4375344"},
+    {file = "zstandard-0.25.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:9654dbc012d8b06fc3d19cc825af3f7bf8ae242226df5f83936cb39f5fdc846c"},
+    {file = "zstandard-0.25.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4203ce3b31aec23012d3a4cf4a2ed64d12fea5269c49aed5e4c3611b938e4088"},
+    {file = "zstandard-0.25.0-cp314-cp314-win32.whl", hash = "sha256:da469dc041701583e34de852d8634703550348d5822e66a0c827d39b05365b12"},
+    {file = "zstandard-0.25.0-cp314-cp314-win_amd64.whl", hash = "sha256:c19bcdd826e95671065f8692b5a4aa95c52dc7a02a4c5a0cac46deb879a017a2"},
+    {file = "zstandard-0.25.0-cp314-cp314-win_arm64.whl", hash = "sha256:d7541afd73985c630bafcd6338d2518ae96060075f9463d7dc14cfb33514383d"},
+    {file = "zstandard-0.25.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b9af1fe743828123e12b41dd8091eca1074d0c1569cc42e6e1eee98027f2bbd0"},
+    {file = "zstandard-0.25.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:4b14abacf83dfb5c25eb4e4a79520de9e7e205f72c9ee7702f91233ae57d33a2"},
+    {file = "zstandard-0.25.0-cp39-cp39-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:a51ff14f8017338e2f2e5dab738ce1ec3b5a851f23b18c1ae1359b1eecbee6df"},
+    {file = "zstandard-0.25.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3b870ce5a02d4b22286cf4944c628e0f0881b11b3f14667c1d62185a99e04f53"},
+    {file = "zstandard-0.25.0-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:05353cef599a7b0b98baca9b068dd36810c3ef0f42bf282583f438caf6ddcee3"},
+    {file = "zstandard-0.25.0-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:19796b39075201d51d5f5f790bf849221e58b48a39a5fc74837675d8bafc7362"},
+    {file = "zstandard-0.25.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:53e08b2445a6bc241261fea89d065536f00a581f02535f8122eba42db9375530"},
+    {file = "zstandard-0.25.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:1f3689581a72eaba9131b1d9bdbfe520ccd169999219b41000ede2fca5c1bfdb"},
+    {file = "zstandard-0.25.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:d8c56bb4e6c795fc77d74d8e8b80846e1fb8292fc0b5060cd8131d522974b751"},
+    {file = "zstandard-0.25.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:53f94448fe5b10ee75d246497168e5825135d54325458c4bfffbaafabcc0a577"},
+    {file = "zstandard-0.25.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:c2ba942c94e0691467ab901fc51b6f2085ff48f2eea77b1a48240f011e8247c7"},
+    {file = "zstandard-0.25.0-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:07b527a69c1e1c8b5ab1ab14e2afe0675614a09182213f21a0717b62027b5936"},
+    {file = "zstandard-0.25.0-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:51526324f1b23229001eb3735bc8c94f9c578b1bd9e867a0a646a3b17109f388"},
+    {file = "zstandard-0.25.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:89c4b48479a43f820b749df49cd7ba2dbc2b1b78560ecb5ab52985574fd40b27"},
+    {file = "zstandard-0.25.0-cp39-cp39-win32.whl", hash = "sha256:1cd5da4d8e8ee0e88be976c294db744773459d51bb32f707a0f166e5ad5c8649"},
+    {file = "zstandard-0.25.0-cp39-cp39-win_amd64.whl", hash = "sha256:37daddd452c0ffb65da00620afb8e17abd4adaae6ce6310702841760c2c26860"},
+    {file = "zstandard-0.25.0.tar.gz", hash = "sha256:7713e1179d162cf5c7906da876ec2ccb9c3a9dcbdffef0cc7f70c3667a205f0b"},
+]
+
+[package.extras]
+cffi = ["cffi (>=1.17,<2.0)", "cffi (>=2.0.0b)"]
+
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "2e3a87590f407b91efdd780b83964ca6b132ff940ff8b37ceb28f8d65433ca21"
+content-hash = "5ff5ba126456f9d73958b3ce61e1766ea13bba1ee4113a460186bfa6e92cf361"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ tqdm = "^4.66.4"
 pyjwt = "^2.10.1"
 inquirerpy = "^0.3.4"
 inflect = "^7.5.0"
+clickhouse-connect = "^0.9.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.1.3"

--- a/src/hdx_cli/cli_interface/logs/commands.py
+++ b/src/hdx_cli/cli_interface/logs/commands.py
@@ -1,3 +1,4 @@
+import re
 from typing import Optional
 
 import click
@@ -5,7 +6,31 @@ import click
 from hdx_cli.cli_interface.common.click_extensions import HdxCommand, HdxGroup
 from hdx_cli.library_api.utility.decorators import ensure_logged_in, report_error_and_exit
 
-from .query import show_logs_logic
+from .query import LEVELS, show_logs_logic
+
+
+def _validate_level(ctx, param, value):
+    """Validate and normalize the log level."""
+    if not value:
+        return None
+
+    for level in LEVELS:
+        if level.lower() == value.lower():
+            # Return the uppercase version
+            return level
+
+    raise click.BadParameter(f"'{value}' is not a valid level. Choose from: {', '.join(LEVELS)}")
+
+
+def _validate_service_name(ctx, param, value):
+    """Validate that the service name contains only safe characters."""
+    if not value:
+        return None
+    if not re.match(r"^[a-zA-Z0-9_.-]+$", value):
+        raise click.BadParameter(
+            f"'{value}' contains invalid characters. Use only alphanumeric, '_', '.', and '-'."
+        )
+    return value
 
 
 @click.group(cls=HdxGroup)
@@ -25,12 +50,13 @@ def logs(ctx: click.Context):
     "-s",
     "service_name",
     help="Filter logs by a specific service name.",
+    callback=_validate_service_name,
 )
 @click.option(
     "--tail",
     "-t",
     "tail_count",
-    type=click.IntRange(min=1),
+    type=click.IntRange(min=1, max=10000),
     default=10,
     help="Show the last N log entries. Defaults to 10.",
 )
@@ -38,7 +64,8 @@ def logs(ctx: click.Context):
     "--level",
     "-l",
     "level_filter",
-    help="Filter by log level (e.g., INFO, ERROR, NONE). Match is exact and case-insensitive.",
+    help=f"Filter by log level. Case-insensitive. Choices: {', '.join(LEVELS)}.",
+    callback=_validate_level,
 )
 @click.option(
     "--filter",
@@ -56,10 +83,8 @@ def show(
     filter_pattern: Optional[str],
 ):
     """Display and filter diagnostic logs from the cluster.
-
-    This command queries the logs table directly, allowing for powerful,
-    server-side filtering to help developers debug issues efficiently.
-    All provided options are combined to build a single query.
+    This command queries the logs table directly, allowing
+    filtering to help developers debug issues efficiently.
 
     \b
     Examples:

--- a/src/hdx_cli/cli_interface/logs/commands.py
+++ b/src/hdx_cli/cli_interface/logs/commands.py
@@ -1,0 +1,79 @@
+from typing import Optional
+
+import click
+
+from hdx_cli.cli_interface.common.click_extensions import HdxCommand, HdxGroup
+from hdx_cli.library_api.utility.decorators import ensure_logged_in, report_error_and_exit
+
+from .query import show_logs_logic
+
+
+@click.group(cls=HdxGroup)
+@click.pass_context
+@report_error_and_exit(exctype=Exception)
+@ensure_logged_in
+def logs(ctx: click.Context):
+    """Provides commands to interact with logs from the cluster."""
+    user_profile = ctx.parent.obj["usercontext"]
+    resource_path = "/query/"
+    ctx.obj = {"resource_path": resource_path, "usercontext": user_profile}
+
+
+@logs.command(cls=HdxCommand, name="show")
+@click.option(
+    "--service",
+    "-s",
+    "service_name",
+    help="Filter logs by a specific service name.",
+)
+@click.option(
+    "--tail",
+    "-t",
+    "tail_count",
+    type=click.IntRange(min=1),
+    default=10,
+    help="Show the last N log entries. Defaults to 10.",
+)
+@click.option(
+    "--level",
+    "-l",
+    "level_filter",
+    help="Filter by log level (e.g., INFO, ERROR, NONE). Match is exact and case-insensitive.",
+)
+@click.option(
+    "--filter",
+    "-f",
+    "filter_pattern",
+    help="Search for a text pattern within the log message.",
+)
+@click.pass_context
+@report_error_and_exit(exctype=Exception)
+def show(
+    ctx: click.Context,
+    service_name: Optional[str],
+    tail_count: Optional[int],
+    level_filter: Optional[str],
+    filter_pattern: Optional[str],
+):
+    """Display and filter diagnostic logs from the cluster.
+
+    This command queries the logs table directly, allowing for powerful,
+    server-side filtering to help developers debug issues efficiently.
+    All provided options are combined to build a single query.
+
+    \b
+    Examples:
+      # Show the last 100 logs from the 'query-peer' service
+      hdxcli logs show --service query-peer --tail 100
+
+    \b
+      # Show all ERROR logs, searching for the term 'segmentation fault'
+      hdxcli logs show --level ERROR --filter "segmentation fault"
+
+    \b
+      # Show logs that do not have a level assigned
+      hdxcli logs show --level none
+    """
+    profile = ctx.parent.obj["usercontext"]
+    resource_path = ctx.parent.obj["resource_path"]
+    show_logs_logic(profile, resource_path, service_name, tail_count, level_filter, filter_pattern)

--- a/src/hdx_cli/cli_interface/logs/commands.py
+++ b/src/hdx_cli/cli_interface/logs/commands.py
@@ -40,8 +40,7 @@ def _validate_service_name(ctx, param, value):
 def logs(ctx: click.Context):
     """Provides commands to interact with logs from the cluster."""
     user_profile = ctx.parent.obj["usercontext"]
-    resource_path = "/query/"
-    ctx.obj = {"resource_path": resource_path, "usercontext": user_profile}
+    ctx.obj = {"usercontext": user_profile}
 
 
 @logs.command(cls=HdxCommand, name="show")
@@ -100,5 +99,4 @@ def show(
       hdxcli logs show --level none
     """
     profile = ctx.parent.obj["usercontext"]
-    resource_path = ctx.parent.obj["resource_path"]
-    show_logs_logic(profile, resource_path, service_name, tail_count, level_filter, filter_pattern)
+    show_logs_logic(profile, service_name, tail_count, level_filter, filter_pattern)

--- a/src/hdx_cli/cli_interface/logs/query.py
+++ b/src/hdx_cli/cli_interface/logs/query.py
@@ -1,16 +1,18 @@
-import csv
-import io
-from typing import Dict, List, Optional
+import logging
+from typing import Dict, List, Optional, Tuple
 
 import click
+import clickhouse_connect
+from clickhouse_connect.driver.exceptions import ClickHouseError
 from rich.console import Console
 from rich.text import Text
 
-from hdx_cli.cli_interface.common.undecorated_click_commands import basic_get
-from hdx_cli.library_api.common.exceptions import HdxCliException, LogicException
+from hdx_cli.library_api.common.exceptions import LogsQueryException, LogsQueryTimeoutException
 from hdx_cli.models import ProfileUserContext
 
+logging.getLogger("clickhouse_connect").setLevel(logging.CRITICAL)
 PAGER_THRESHOLD = 20
+DEFAULT_CLICKHOUSE_PORT = 8088
 console = Console(soft_wrap=True)
 
 # Static list of levels for user input validation
@@ -26,102 +28,107 @@ LEVEL_VARIATIONS = {
 }
 
 
-def _sanitize_for_sql(text: str) -> str:
-    """Escapes single quotes."""
-    return text.replace("'", "''")
-
-
 def _build_query(
     service: Optional[str],
     level: Optional[str],
     text_filter: Optional[str],
     tail: Optional[int],
-) -> str:
-    """Constructs the SQL query string based on the provided filters."""
-    select_clause = "SELECT timestamp, level, kubernetes.container_name AS service, message, error"
+) -> Tuple[str, Dict]:
+    """
+    Constructs a parameterized query template and a parameter's dictionary.
+    """
+    select_clause = (
+        "SELECT timestamp, level, `kubernetes.container_name` AS service, message, error"
+    )
+    params = {}
     conditions = []
 
     if service:
-        conditions.append(f"service = '{service}'")
+        conditions.append("service = %(service_name)s")
+        params["service_name"] = service
 
     if level:
-        canonical_level = level.upper()
-        if canonical_level == "NONE":
+        if level == "NONE":
             conditions.append("level IS NULL")
         else:
-            variations = LEVEL_VARIATIONS.get(canonical_level, ())
+            variations = LEVEL_VARIATIONS.get(level, ())
             if variations:
-                in_clause = ", ".join(f"'{v}'" for v in variations)
-                conditions.append(f"level IN ({in_clause})")
+                params["level_variations"] = tuple(variations)
+                conditions.append("level IN %(level_variations)s")
 
     if text_filter:
-        sanitized_filter = _sanitize_for_sql(text_filter)
-        conditions.append(f"message LIKE '%{sanitized_filter}%'")
+        params["text_pattern"] = f"%{text_filter}%"
+        or_clause = "(message LIKE %(text_pattern)s OR error LIKE %(text_pattern)s)"
+        conditions.append(or_clause)
 
     where_clause = ""
     if conditions:
         where_clause = "WHERE " + " AND ".join(conditions)
 
-    limit_clause = f"LIMIT {tail}"
+    limit_clause = "LIMIT %(limit_val)s"
+    params["limit_val"] = tail
 
-    query = f"{select_clause} FROM hydro.logs {where_clause} ORDER BY timestamp DESC {limit_clause} FORMAT CSVWithNames"
-    return query
+    template = (
+        f"{select_clause} FROM hydro.logs {where_clause} ORDER BY timestamp DESC {limit_clause}"
+    )
+    return template, params
 
 
 def _execute_query(
     profile: ProfileUserContext,
-    resource_path: str,
-    query: str,
+    query_template: str,
+    params: Dict,
 ) -> List[Dict]:
-    """
-    Executes the query against the API, receives CSV data,
-    and parses it into a list of dictionaries.
-    """
-    response_data = basic_get(profile, resource_path, fmt="verbatim", query=query)
-
-    if not isinstance(response_data, bytes):
-        raise LogicException("The query API did not return bytes as expected.")
+    hostname = profile.hostname
+    base_host = hostname.split(":", 1)[0]
 
     try:
-        decoded_csv = response_data.decode("utf-8")
-        csv_file = io.StringIO(decoded_csv)
-        reader = csv.DictReader(csv_file)
-        logs = list(reader)
-        return logs
-    except (UnicodeDecodeError, csv.Error) as e:
-        raise LogicException(f"Failed to parse the CSV response from the API: {e}")
+        client = clickhouse_connect.get_client(
+            host=base_host,
+            port=DEFAULT_CLICKHOUSE_PORT,
+            username="bearer",
+            password=profile.token,
+            secure=True,
+            send_receive_timeout=profile.timeout,
+        )
+        result = client.query(query_template, parameters=params)
+
+        return [dict(zip(result.column_names, row)) for row in result.result_rows]
+    except ClickHouseError as e:
+        if "timed out" in str(e).lower():
+            raise LogsQueryTimeoutException(timeout=profile.timeout) from e
+        else:
+            error_message = f"The logs query failed.\n  └─ Reason: {e}"
+            raise LogsQueryException(error_message) from e
 
 
 def _format_logs(logs: List[Dict]) -> List[Text]:
-    """Formats the log dictionaries into rich Text objects for display."""
     formatted_logs = []
     for log in logs:
         log_level_original = log.get("level")
-        log_level_normalized = (
-            log_level_original.upper()
-            if log_level_original and log_level_original != r"\N"
-            else "NONE"
+        log_level_normalized = log_level_original.upper() if log_level_original else "NONE"
+
+        timestamp_dt = log.get("timestamp")
+        timestamp_str = (
+            timestamp_dt.strftime("%Y-%m-%d %H:%M:%S.%f")[:-3] if timestamp_dt else " " * 23
         )
 
-        timestamp = log.get("timestamp", " " * 19)
-        service_original = log.get("service")
-        message_original = log.get("message", "")
+        service = log.get("service", "n/a")
+        message = log.get("message", "")
         error_details = log.get("error")
 
-        service = "n/a" if not service_original or service_original == r"\N" else service_original
-        message = "" if message_original == r"\N" else message_original
-        sanitized_message = message.replace("\r", "").strip()
+        sanitized_message = message.replace("\r", "").strip() if message else ""
 
         line = Text.assemble(
-            (f"{timestamp} ", "dim"),
+            (f"{timestamp_str} ", "dim"),
             (f"[{log_level_normalized}] ", "bold"),
             (f"[{service}] ", "green"),
             sanitized_message,
         )
 
-        if error_details and error_details.strip() and error_details != r"\N":
-            sanitized_error = error_details.replace("\r", "").strip()
+        if error_details:
             # Append the error line if exists.
+            sanitized_error = str(error_details).replace("\r", "").strip()
             error_line = Text(f"\n  └─ Error: {sanitized_error}", style="red")
             line.append(error_line)
 
@@ -157,7 +164,6 @@ def _display_logs(formatted_logs: List[Text]):
 
 def show_logs_logic(
     profile: ProfileUserContext,
-    resource_path: str,
     service: Optional[str],
     tail: Optional[int],
     level: Optional[str],
@@ -165,8 +171,8 @@ def show_logs_logic(
 ):
     """Main orchestrator for the 'logs show' command logic."""
     with console.status("[dim]Querying and processing logs...[/]"):
-        query = _build_query(service, level, filter_pattern, tail)
-        logs_from_api = _execute_query(profile, resource_path, query)
+        query_template, params = _build_query(service, level, filter_pattern, tail)
+        logs_from_api = _execute_query(profile, query_template, params)
         formatted_logs = _format_logs(logs_from_api)
 
     _display_logs(formatted_logs)

--- a/src/hdx_cli/cli_interface/logs/query.py
+++ b/src/hdx_cli/cli_interface/logs/query.py
@@ -1,0 +1,145 @@
+import csv
+import io
+from typing import Dict, List, Optional
+
+import click
+from rich.console import Console
+from rich.text import Text
+
+from hdx_cli.cli_interface.common.undecorated_click_commands import basic_get
+from hdx_cli.library_api.common.exceptions import LogicException
+from hdx_cli.models import ProfileUserContext
+
+PAGER_THRESHOLD = 20
+console = Console(soft_wrap=True)
+
+
+def _build_query(
+    service: Optional[str],
+    level: Optional[str],
+    text_filter: Optional[str],
+    tail: Optional[int],
+) -> str:
+    """Constructs the SQL query string based on the provided filters."""
+    select_clause = "SELECT timestamp, level, kubernetes.container_name AS service, message, error"
+
+    conditions = []
+    if service:
+        conditions.append(f"service = '{service}'")
+    if level:
+        conditions.append(f"lower(level) = '{level.lower()}'")
+    if text_filter:
+        conditions.append(f"message LIKE '%{text_filter}%'")
+
+    where_clause = ""
+    if conditions:
+        where_clause = "WHERE " + " AND ".join(conditions)
+
+    limit_clause = f"LIMIT {tail}"
+
+    query = f"{select_clause} FROM hydro.logs {where_clause} ORDER BY timestamp DESC {limit_clause} FORMAT CSVWithNames"
+    return query
+
+
+def _execute_query(
+    profile: ProfileUserContext,
+    resource_path: str,
+    query: str,
+) -> List[Dict]:
+    """
+    Executes the query against the API, receives CSV data,
+    and parses it into a list of dictionaries.
+    """
+    response_data = basic_get(profile, resource_path, fmt="verbatim", query=query)
+
+    if not isinstance(response_data, bytes):
+        raise LogicException("The query API did not return bytes as expected.")
+
+    try:
+        decoded_csv = response_data.decode("utf-8")
+        csv_file = io.StringIO(decoded_csv)
+        reader = csv.DictReader(csv_file)
+        logs = list(reader)
+        return logs
+    except (UnicodeDecodeError, csv.Error) as e:
+        raise LogicException(f"Failed to parse the CSV response from the API: {e}")
+
+
+def _format_logs(logs: List[Dict]) -> List[Text]:
+    """Formats the log dictionaries into rich Text objects for display."""
+    formatted_logs = []
+    for log in logs:
+        log_level_original = log.get("level")
+        log_level_normalized = (
+            log_level_original.upper()
+            if log_level_original and log_level_original != r"\N"
+            else "NONE"
+        )
+
+        timestamp = log.get("timestamp", " " * 19)
+        service_original = log.get("service")
+        message_original = log.get("message", "")
+        error_details = log.get("error")
+
+        service = "n/a" if not service_original or service_original == r"\N" else service_original
+        message = "" if message_original == r"\N" else message_original
+        sanitized_message = message.replace("\r", "").strip()
+
+        line = Text.assemble(
+            (f"{timestamp} ", "dim"),
+            (f"[{log_level_normalized}] ", "bold"),
+            (f"[{service}] ", "green"),
+            sanitized_message,
+        )
+
+        if error_details and error_details.strip() and error_details != r"\N":
+            sanitized_error = error_details.replace("\r", "").strip()
+            # Append the error line if exists.
+            error_line = Text(f"\n  └─ Error: {sanitized_error}", style="red")
+            line.append(error_line)
+
+        formatted_logs.append(line)
+
+    return formatted_logs
+
+
+def _display_logs(formatted_logs: List[Text]):
+    """
+    Displays the logs, capturing the output and using click's pager
+    if the number of logs exceeds the threshold.
+    """
+    if not formatted_logs:
+        console.print("No logs to display with the current filters.")
+        return
+
+    formatted_logs.reverse()
+
+    if len(formatted_logs) > PAGER_THRESHOLD:
+        # Print to the main console inside the 'with' block.
+        with console.capture() as capture:
+            for line in formatted_logs:
+                console.print(line)
+
+        # Get the captured string and pass it to click's pager.
+        output = capture.get()
+        click.echo_via_pager(output)
+    else:
+        for line in formatted_logs:
+            console.print(line)
+
+
+def show_logs_logic(
+    profile: ProfileUserContext,
+    resource_path: str,
+    service: Optional[str],
+    tail: Optional[int],
+    level: Optional[str],
+    filter_pattern: Optional[str],
+):
+    """Main orchestrator for the 'logs show' command logic."""
+    with console.status("[dim]Querying and processing logs...[/]"):
+        query = _build_query(service, level, filter_pattern, tail)
+        logs_from_api = _execute_query(profile, resource_path, query)
+        formatted_logs = _format_logs(logs_from_api)
+
+    _display_logs(formatted_logs)

--- a/src/hdx_cli/cli_interface/logs/query.py
+++ b/src/hdx_cli/cli_interface/logs/query.py
@@ -7,11 +7,28 @@ from rich.console import Console
 from rich.text import Text
 
 from hdx_cli.cli_interface.common.undecorated_click_commands import basic_get
-from hdx_cli.library_api.common.exceptions import LogicException
+from hdx_cli.library_api.common.exceptions import HdxCliException, LogicException
 from hdx_cli.models import ProfileUserContext
 
 PAGER_THRESHOLD = 20
 console = Console(soft_wrap=True)
+
+# Static list of levels for user input validation
+LEVELS = ["INFO", "WARN", "ERROR", "TRACE", "FATAL", "NONE"]
+
+# Mapping of levels
+LEVEL_VARIATIONS = {
+    "INFO": ("info", "INFO"),
+    "WARN": ("warn", "WARN", "warning", "WARNING"),
+    "ERROR": ("error", "ERROR"),
+    "FATAL": ("fatal", "FATAL"),
+    "TRACE": ("trace", "TRACE"),
+}
+
+
+def _sanitize_for_sql(text: str) -> str:
+    """Escapes single quotes."""
+    return text.replace("'", "''")
 
 
 def _build_query(
@@ -22,14 +39,24 @@ def _build_query(
 ) -> str:
     """Constructs the SQL query string based on the provided filters."""
     select_clause = "SELECT timestamp, level, kubernetes.container_name AS service, message, error"
-
     conditions = []
+
     if service:
         conditions.append(f"service = '{service}'")
+
     if level:
-        conditions.append(f"lower(level) = '{level.lower()}'")
+        canonical_level = level.upper()
+        if canonical_level == "NONE":
+            conditions.append("level IS NULL")
+        else:
+            variations = LEVEL_VARIATIONS.get(canonical_level, ())
+            if variations:
+                in_clause = ", ".join(f"'{v}'" for v in variations)
+                conditions.append(f"level IN ({in_clause})")
+
     if text_filter:
-        conditions.append(f"message LIKE '%{text_filter}%'")
+        sanitized_filter = _sanitize_for_sql(text_filter)
+        conditions.append(f"message LIKE '%{sanitized_filter}%'")
 
     where_clause = ""
     if conditions:

--- a/src/hdx_cli/library_api/common/exceptions.py
+++ b/src/hdx_cli/library_api/common/exceptions.py
@@ -153,3 +153,27 @@ class RCloneRemoteCheckException(RCloneRemoteException):
     def __init__(self, bucket_name, cloud):
         message = f"Error checking remote connection to {bucket_name} ({cloud})."
         super().__init__(message)
+
+
+class LogsCommandException(HdxCliException):
+    """Base exception for all errors related to the 'logs' command."""
+
+    pass
+
+
+class LogsQueryException(LogsCommandException):
+    """Raised when a log query fails."""
+
+    def __init__(self, message: str):
+        super().__init__(message)
+
+
+class LogsQueryTimeoutException(LogsQueryException):
+    """A specific type of query error for timeouts."""
+
+    def __init__(self, timeout: int):
+        message = (
+            f"The query timed out after {timeout} seconds. Your request may be too broad. "
+            "Try reducing the scope with --tail or other filters."
+        )
+        super().__init__(message)

--- a/src/hdx_cli/main.py
+++ b/src/hdx_cli/main.py
@@ -1,19 +1,21 @@
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
 import click
-from importlib.metadata import version, PackageNotFoundError
 from trogon import tui
 
 from hdx_cli.auth.context_builder import load_user_context
 from hdx_cli.cli_interface.check_health import commands as check_health_
 from hdx_cli.cli_interface.column import commands as column_
-from hdx_cli.cli_interface.common.click_extensions import HdxGroup, HdxCommand
+from hdx_cli.cli_interface.common.click_extensions import HdxCommand, HdxGroup
 from hdx_cli.cli_interface.credential import commands as credentials_
 from hdx_cli.cli_interface.defaults import commands as defaults_
 from hdx_cli.cli_interface.dictionary import commands as dictionary_
+from hdx_cli.cli_interface.docs import commands as docs_
 from hdx_cli.cli_interface.function import commands as function_
 from hdx_cli.cli_interface.integration import commands as integration_
 from hdx_cli.cli_interface.job import commands as job_
+from hdx_cli.cli_interface.logs import commands as logs_
 from hdx_cli.cli_interface.migrate import commands as migrate_
 from hdx_cli.cli_interface.pool import commands as pool_
 from hdx_cli.cli_interface.profile import commands as profile_
@@ -32,7 +34,6 @@ from hdx_cli.cli_interface.table import commands as table_
 from hdx_cli.cli_interface.transform import commands as transform_
 from hdx_cli.cli_interface.user import commands as user_
 from hdx_cli.cli_interface.view import commands as view_
-from hdx_cli.cli_interface.docs import commands as docs_
 from hdx_cli.config.initial_setup import first_time_use_config, is_first_time_use
 from hdx_cli.library_api.common.config_constants import PROFILE_CONFIG_FILE
 from hdx_cli.library_api.common.exceptions import ConfigurationExistsException
@@ -56,6 +57,7 @@ def configure_logger(debug=False):
 
 
 # pylint: disable=line-too-long
+
 
 @tui(help="Open a Textual User Interface (TUI) for the CLI.")
 @click.group(cls=HdxGroup)
@@ -252,6 +254,7 @@ hdx_cli.add_command(resource_summary_.resource_summary)
 hdx_cli.add_command(defaults_.show_defaults)
 hdx_cli.add_command(version)
 hdx_cli.add_command(docs_.docs)
+hdx_cli.add_command(logs_.logs)
 
 
 def main():


### PR DESCRIPTION
This PR introduces a new command group, `hdxcli logs`, with a `show` command. This provides a way to query and view logs directly from the `hydro.logs` table. This new implementation uses a direct query approach.
```shell
hdxcli logs show --help
Usage: hdxcli logs show [OPTIONS]

  Display and filter diagnostic logs from the cluster.

  This command queries the logs table directly, allowing for powerful, server-
  side filtering to help developers debug issues efficiently. All provided
  options are combined to build a single query.

  Examples:
    # Show the last 100 logs from the 'query-peer' service
    hdxcli logs show --service query-peer --tail 100

    # Show all ERROR logs, searching for the term 'segmentation fault'
    hdxcli logs show --level ERROR --filter "segmentation fault"

    # Show logs that do not have a level assigned
    hdxcli logs show --level none

Options:
  -s, --service TEXT        Filter logs by a specific service name.
  -t, --tail INTEGER RANGE  Show the last N log entries. Defaults to 10.
                            [x>=1]
  -l, --level TEXT          Filter by log level (e.g., INFO, ERROR, NONE).
                            Match is exact and case-insensitive.
  -f, --filter TEXT         Search for a text pattern within the log message.
  --help                    Show this message and exit.
``` 

### Examples: 
<img width="547" height="137" alt="image" src="https://github.com/user-attachments/assets/041ec75b-cc8a-4590-ac65-ece5a4c26565" />

<img width="929" height="210" alt="image" src="https://github.com/user-attachments/assets/bcc34d04-abae-4ad9-8f66-6148cea4011b" />

