### PR TITLE
[HDX-8033] Centralize error handling and debugging

### DIFF
--- a/src/hdx_cli/cli_interface/check_health/commands.py
+++ b/src/hdx_cli/cli_interface/check_health/commands.py
@@ -5,8 +5,9 @@ from hdx_cli.cli_interface.common.undecorated_click_commands import basic_update
 from hdx_cli.library_api.common.exceptions import ResourceNotFoundException
 from hdx_cli.library_api.common.generic_resource import access_resource_detailed
 from hdx_cli.library_api.common.logging import get_logger
-from hdx_cli.library_api.utility.decorators import report_error_and_exit, ensure_logged_in
+from hdx_cli.library_api.utility.decorators import ensure_logged_in
 from hdx_cli.models import ProfileUserContext
+
 from . import const, utils
 from .cleaner import table as table_cleaner
 
@@ -33,7 +34,6 @@ logger = get_logger()
     help="Attempt to automatically repair detected issues.",
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 @ensure_logged_in
 def check_health(
     ctx: click.Context,

--- a/src/hdx_cli/cli_interface/column/commands.py
+++ b/src/hdx_cli/cli_interface/column/commands.py
@@ -6,11 +6,7 @@ from hdx_cli.cli_interface.common.rest_operations import list_ as command_list
 from hdx_cli.cli_interface.common.rest_operations import show as command_show
 from hdx_cli.cli_interface.common.undecorated_click_commands import basic_column, basic_create
 from hdx_cli.library_api.common.logging import get_logger
-from hdx_cli.library_api.utility.decorators import (
-    ensure_logged_in,
-    report_error_and_exit,
-    skip_group_logic_on_help,
-)
+from hdx_cli.library_api.utility.decorators import ensure_logged_in
 from hdx_cli.models import ProfileUserContext
 
 logger = get_logger()
@@ -39,8 +35,6 @@ logger = get_logger()
     default=None,
 )
 @click.pass_context
-@skip_group_logic_on_help
-@report_error_and_exit(exctype=Exception)
 @ensure_logged_in
 def column(ctx: click.Context, project_name: str, table_name: str, column_name: str):
     """Commands to manage table columns.
@@ -62,7 +56,6 @@ def column(ctx: click.Context, project_name: str, table_name: str, column_name: 
 @click.command(cls=HdxCommand, name="add-name")
 @click.argument("new_name", metavar="NEW_NAME", required=True)
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def add_name(ctx: click.Context, new_name: str):
     """Assigns an additional name to an existing {resource}.
     Requires `--project`, `--table`, and `--column` options to be set.
@@ -98,7 +91,6 @@ def add_name(ctx: click.Context, new_name: str):
 @click.argument("alias_name", metavar="ALIAS_NAME", required=True)
 @click.argument("expression", metavar="EXPRESSION", required=True)
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def add_alias(ctx: click.Context, alias_name: str, expression: str):
     """Creates a new {resource} defined by an expression.
     Requires `--project` and `--table` options to be set.

--- a/src/hdx_cli/cli_interface/common/click_extensions.py
+++ b/src/hdx_cli/cli_interface/common/click_extensions.py
@@ -1,10 +1,13 @@
 import inspect
 import re
+import sys
 
 import click
 import inflect
 
+from hdx_cli.library_api.common.exceptions import HdxCliException, HttpException
 from hdx_cli.library_api.common.logging import get_logger
+from hdx_cli.library_api.utility.json_util import http_error_pretty_format
 
 _inflect_engine = inflect.engine()
 logger = get_logger()
@@ -152,11 +155,7 @@ class HdxCommand(click.Command):
     """A custom click.Command."""
 
     def to_markdown(self, ctx: click.Context) -> str:
-        resource = ctx.parent.command.name if ctx.parent else self.name
-        for param in self.get_params(ctx):
-            if isinstance(param, click.Argument) and param.name == "resource_name":
-                param.metavar = f"{resource.replace('-', '_').upper()}_NAME"
-
+        self._update_resource_name_metavar(ctx)
         depth = _get_depth(ctx)
         heading = "#" * depth
         command_title = self.name.replace("-", " ").replace("_", " ").title()
@@ -191,14 +190,29 @@ class HdxCommand(click.Command):
 
         return "\n".join(md_parts)
 
-    def get_help(self, ctx: click.Context) -> str:
-        """Formats the command's help text, letting Click handle truncation via '\\f'."""
-        # Update metavar before calling super().get_help()
+    def _update_resource_name_metavar(self, ctx: click.Context):
+        """
+        Dynamically updates the metavar for the 'resource_name' argument
+        based on the parent group's name (e.g., 'project').
+        """
+        # Determine the resource name from the parent command group (e.g., 'project', 'table')
         resource = ctx.parent.command.name if ctx.parent else self.name
         for param in self.params:
             if isinstance(param, click.Argument) and param.name == "resource_name":
                 param.metavar = f"{resource.replace('-', '_').upper()}_NAME"
 
+    def get_usage(self, ctx: click.Context) -> str:
+        """
+        Overrides the default get_usage to ensure the resource_name
+        metavar is updated before the usage string is generated.
+        """
+        self._update_resource_name_metavar(ctx)
+        return super().get_usage(ctx)
+
+    def get_help(self, ctx: click.Context) -> str:
+        """Formats the command's help text, letting Click handle truncation via '\\f'."""
+        # Update metavar before calling super().get_help()
+        self._update_resource_name_metavar(ctx)
         help_text = super().get_help(ctx)
         if not help_text:
             return ""
@@ -213,6 +227,23 @@ class HdxCommand(click.Command):
 
 class HdxGroup(click.Group):
     """A custom click.Group."""
+
+    def invoke(self, ctx: click.Context):
+        """
+        Overrides default invocation to skip the group's callback if a help
+        option is present, preventing validation errors on required options.
+        """
+        if "--help" in sys.argv or "-h" in sys.argv:
+            original_callback = self.callback
+            self.callback = None
+            try:
+                return super().invoke(ctx)
+            finally:
+                # Restore the callback to ensure the group object's state is not permanently altered.
+                self.callback = original_callback
+        else:
+            # No help option found, proceed with the standard invocation.
+            return super().invoke(ctx)
 
     def to_markdown(self, ctx: click.Context) -> str:
         depth = _get_depth(ctx)
@@ -275,3 +306,35 @@ class HdxGroup(click.Group):
         except KeyError as e:
             logger.debug(f"Error formatting help for group '{self.name}': {e}.")
             return help_text
+
+
+class HdxCliGroup(HdxGroup):
+    """
+    A custom click.Group that extends HdxGroup to add centralized,
+    debug-friendly exception handling for the entire CLI application.
+    """
+
+    def main(self, *args, **kwargs):
+        try:
+            return super().main(*args, **kwargs)
+        except KeyboardInterrupt:
+            click.echo("\nAborted by user.", err=True)
+            sys.exit(1)
+        except Exception as e:
+            if "--debug" in sys.argv:
+                # Re-raise the original exception for debugging purposes
+                raise
+
+            if isinstance(e, (click.Abort, click.ClickException)):
+                sys.exit(1)
+            elif isinstance(e, HttpException):
+                message = http_error_pretty_format(e)
+                click.echo(f"Error: {message}", err=True)
+            elif isinstance(e, HdxCliException):
+                click.echo(f"Error: {e}", err=True)
+            else:
+                # For all unexpected exceptions, display the error directly.
+                click.echo(f"Error: {e}", err=True)
+                click.echo("Use --debug to see full traceback.", err=True)
+
+            sys.exit(1)

--- a/src/hdx_cli/cli_interface/common/misc_operations.py
+++ b/src/hdx_cli/cli_interface/common/misc_operations.py
@@ -5,7 +5,6 @@ import click
 
 from hdx_cli.cli_interface.common.click_extensions import HdxCommand
 from hdx_cli.cli_interface.common.undecorated_click_commands import basic_settings
-from hdx_cli.library_api.utility.decorators import report_error_and_exit
 
 
 def _value_formatter(value: str) -> Any:
@@ -32,10 +31,9 @@ def _value_formatter(value: str) -> Any:
     "--force",
     is_flag=True,
     default=False,
-    help='This flag allows adding the `force_operation` parameter to the request.',
+    help="This flag allows adding the `force_operation` parameter to the request.",
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def settings(ctx: click.Context, key: str | None, value: str | None, force: bool):
     """List, get, or set key-value settings for a specific {resource}.
 

--- a/src/hdx_cli/cli_interface/common/rest_operations.py
+++ b/src/hdx_cli/cli_interface/common/rest_operations.py
@@ -4,15 +4,15 @@ import click
 
 from hdx_cli.cli_interface.common.click_extensions import HdxCommand
 from hdx_cli.cli_interface.common.undecorated_click_commands import (
+    basic_activity,
     basic_delete,
     basic_list,
     basic_show,
-    basic_activity,
-    basic_stats
+    basic_stats,
 )
 from hdx_cli.library_api.common.exceptions import LogicException
 from hdx_cli.library_api.common.logging import get_logger
-from hdx_cli.library_api.utility.decorators import dynamic_confirmation_prompt, report_error_and_exit
+from hdx_cli.library_api.utility.decorators import dynamic_confirmation_prompt
 
 logger = get_logger()
 
@@ -35,7 +35,6 @@ _confirmation_prompt = partial(
 )
 @click.argument("resource_name")
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def delete(ctx: click.Context, resource_name: str, disable_confirmation_prompt: bool) -> None:
     """Delete a specific {resource}.
 
@@ -60,7 +59,6 @@ def delete(ctx: click.Context, resource_name: str, disable_confirmation_prompt: 
 @click.option("--page", "-p", type=int, default=1, help="Page number.")
 @click.option("--page-size", "-s", type=int, default=None, help="Number of items per page.")
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def list_(ctx: click.Context, page: int, page_size: int) -> None:
     """List all available {resource_plural}.
 
@@ -81,7 +79,6 @@ def list_(ctx: click.Context, page: int, page_size: int) -> None:
 @click.argument("resource_name", required=False, default=None)
 @click.option("-i", "--indent", is_flag=True, default=False, help="Indent the output.")
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def show(ctx: click.Context, resource_name: str, indent: bool) -> None:
     """Show details for a specific {resource}.
 
@@ -114,7 +111,6 @@ def show(ctx: click.Context, resource_name: str, indent: bool) -> None:
 @click.option("--page", "-p", type=int, default=1, help="Page number.")
 @click.option("--page-size", "-s", type=int, default=None, help="Number of items per page.")
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def activity(ctx: click.Context, resource_name: str, page: int, page_size: int) -> None:
     """Shows the log of recent activities for the provided {resource}.
 
@@ -144,8 +140,7 @@ def activity(ctx: click.Context, resource_name: str, page: int, page_size: int) 
 @click.argument("resource_name", required=False, default=None)
 @click.option("-i", "--indent", is_flag=True, default=False, help="Indent the output.")
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
-def stats(ctx: click.Context, resource_name:str, indent: bool) -> None:
+def stats(ctx: click.Context, resource_name: str, indent: bool) -> None:
     """Shows usage and other statistics for the provided {resource}.
 
     \b

--- a/src/hdx_cli/cli_interface/credential/commands.py
+++ b/src/hdx_cli/cli_interface/credential/commands.py
@@ -4,15 +4,15 @@ from rich.columns import Columns
 from rich.console import Console
 from rich.table import Table
 
-from hdx_cli.cli_interface.common.click_extensions import HdxGroup, HdxCommand
-from hdx_cli.cli_interface.common.undecorated_click_commands import basic_create
+from hdx_cli.cli_interface.common.click_extensions import HdxCommand, HdxGroup
 from hdx_cli.cli_interface.common.misc_operations import settings as command_settings
 from hdx_cli.cli_interface.common.rest_operations import delete as command_delete
 from hdx_cli.cli_interface.common.rest_operations import list_ as command_list
 from hdx_cli.cli_interface.common.rest_operations import show as command_show
+from hdx_cli.cli_interface.common.undecorated_click_commands import basic_create
 from hdx_cli.library_api.common.generic_resource import access_resource
 from hdx_cli.library_api.common.logging import get_logger
-from hdx_cli.library_api.utility.decorators import report_error_and_exit, ensure_logged_in
+from hdx_cli.library_api.utility.decorators import ensure_logged_in
 from hdx_cli.models import ProfileUserContext
 
 logger = get_logger()
@@ -28,7 +28,6 @@ console = Console()
     help="Perform operation on the passed credential.",
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 @ensure_logged_in
 def credential(ctx: click.Context, credential_name: str):
     """Provides commands to create, list, show, and delete credentials.
@@ -49,7 +48,7 @@ def credential(ctx: click.Context, credential_name: str):
 @click.option("--description", required=False, help="Credential description.")
 @click.option(
     "--detail",
-     "details",
+    "details",
     required=False,
     default=None,
     nargs=2,
@@ -57,7 +56,6 @@ def credential(ctx: click.Context, credential_name: str):
     help="A key-value pair for a credential detail. Use multiple times for multiple details.",
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def create(
     ctx: click.Context,
     resource_name: str,
@@ -128,7 +126,6 @@ def create(
     help="Filter the credential types by a specific cloud.",
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def list_types(ctx: click.Context, cloud: str):
     """List available {resource} types.
 

--- a/src/hdx_cli/cli_interface/defaults/commands.py
+++ b/src/hdx_cli/cli_interface/defaults/commands.py
@@ -8,7 +8,7 @@ from rich.text import Text
 
 from hdx_cli.cli_interface.common.click_extensions import HdxCommand
 from hdx_cli.cli_interface.common.undecorated_click_commands import basic_get
-from hdx_cli.library_api.utility.decorators import ensure_logged_in, report_error_and_exit
+from hdx_cli.library_api.utility.decorators import ensure_logged_in
 from hdx_cli.models import ProfileUserContext
 
 console = Console()
@@ -113,7 +113,6 @@ def _show_defaults(profile: ProfileUserContext, categories: List[str]):
 @click.command(cls=HdxCommand, name="show-defaults")
 @click.argument("category", nargs=-1, required=False)
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 @ensure_logged_in
 def show_defaults(ctx: click.Context, category: List[str]):
     """Show default settings for various resources.

--- a/src/hdx_cli/cli_interface/dictionary/commands.py
+++ b/src/hdx_cli/cli_interface/dictionary/commands.py
@@ -20,8 +20,6 @@ from hdx_cli.library_api.common.logging import get_logger
 from hdx_cli.library_api.utility.decorators import (
     ensure_logged_in,
     no_rollback_option,
-    report_error_and_exit,
-    skip_group_logic_on_help,
     target_cluster_options,
 )
 from hdx_cli.library_api.utility.file_handling import read_bytes_from_file, read_json_from_file
@@ -48,8 +46,6 @@ logger = get_logger()
     default=None,
 )
 @click.pass_context
-@skip_group_logic_on_help
-@report_error_and_exit(exctype=Exception)
 @ensure_logged_in
 def dictionary(ctx: click.Context, project_name: str, dictionary_name: str):
     """This group of commands allows creating, listing, showing, deleting,
@@ -83,7 +79,6 @@ def dictionary(ctx: click.Context, project_name: str, dictionary_name: str):
 @click.argument("dict_file_name", metavar="DICT_FILE_NAME")
 @click.argument("resource_name")
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def create(
     ctx: click.Context,
     dict_settings_file_path: str,
@@ -124,7 +119,6 @@ def create(
 @target_cluster_options
 @no_rollback_option
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def migrate(
     ctx: click.Context,
     target_project_name: str,
@@ -204,7 +198,6 @@ def migrate(
     default=None,
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def download_file(ctx: click.Context, dictionary_filename: str, output_path: str):
     """
     Download a dictionary data file to your local machine.
@@ -232,8 +225,6 @@ def download_file(ctx: click.Context, dictionary_filename: str, output_path: str
 
 @click.group(cls=HdxGroup)
 @click.pass_context
-@skip_group_logic_on_help
-@report_error_and_exit(exctype=Exception)
 def files(ctx: click.Context):
     """Manage dictionary data files."""
     user_profile = ctx.parent.obj["usercontext"]
@@ -256,7 +247,6 @@ def files(ctx: click.Context):
     default="json",
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def files_upload(
     ctx: click.Context,
     file_path_to_upload: str,
@@ -286,7 +276,6 @@ def files_upload(
 @click.command(cls=HdxCommand)
 @click.argument("file_name", metavar="FILE_NAME")
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def files_delete(ctx: click.Context, file_name: str):
     """Delete a dictionary data file.
 

--- a/src/hdx_cli/cli_interface/docs/commands.py
+++ b/src/hdx_cli/cli_interface/docs/commands.py
@@ -1,10 +1,11 @@
-import click
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
-from importlib.metadata import version, PackageNotFoundError
+
+import click
 
 from hdx_cli.cli_interface.common.click_extensions import HdxCommand
 from hdx_cli.library_api.common.logging import get_logger
-from hdx_cli.library_api.utility.decorators import report_error_and_exit
+
 from .config import DOC_STRUCTURE
 
 logger = get_logger()
@@ -17,13 +18,12 @@ except PackageNotFoundError:
 
 @click.command(cls=HdxCommand, name="docs")
 @click.argument(
-    'target_dir',
+    "target_dir",
     type=click.Path(file_okay=False, writable=True, resolve_path=True),
     required=True,
 )
-@click.argument('resource', metavar="RESOURCE_NAME", required=False)
+@click.argument("resource", metavar="RESOURCE_NAME", required=False)
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def docs(ctx: click.Context, target_dir: str, resource: str = None):
     """
     Generate and export CLI documentation in Markdown format.
@@ -69,7 +69,7 @@ def _generate_full_docs(root_ctx: click.Context, output_path: Path):
         frontmatter_parts = ["---"]
         for key, value in frontmatter_data.items():
             if isinstance(value, bool):
-                frontmatter_parts.append(f'{key}: {str(value).lower()}')
+                frontmatter_parts.append(f"{key}: {str(value).lower()}")
             else:
                 frontmatter_parts.append(f'{key}: "{value}"')
         frontmatter_parts.append("---")
@@ -83,7 +83,7 @@ def _generate_full_docs(root_ctx: click.Context, output_path: Path):
         body_parts = []
         for command_name in command_names:
             command = root_ctx.command.get_command(root_ctx, command_name)
-            if command and hasattr(command, 'to_markdown'):
+            if command and hasattr(command, "to_markdown"):
                 cmd_ctx = click.Context(command, info_name=command_name, parent=root_ctx)
                 md_content = command.to_markdown(cmd_ctx)
                 body_parts.append(md_content)
@@ -105,19 +105,21 @@ def _generate_single_resource_doc(root_ctx: click.Context, resource_name: str, o
     if not command:
         raise click.UsageError(f"Error: Command or group '{resource_name}' not found.")
 
-    if hasattr(command, 'to_markdown'):
+    if hasattr(command, "to_markdown"):
         md_content = command.to_markdown(cmd_ctx)
         version_line = f"> _hdxcli v{VERSION}_"
 
-        lines = md_content.split('\n')
+        lines = md_content.split("\n")
         lines.insert(1, f"\n{version_line}\n")
-        final_md_content = '\n'.join(lines)
+        final_md_content = "\n".join(lines)
 
         file_path = output_path / f"{resource_name}.md"
         file_path.write_text(final_md_content, encoding="utf-8")
         logger.info(f"Successfully generated documentation for '{resource_name}' at '{file_path}'.")
     else:
-        logger.warning(f"Warning: Resource '{resource_name}' does not support documentation export.")
+        logger.warning(
+            f"Warning: Resource '{resource_name}' does not support documentation export."
+        )
 
 
 def _find_command_recursively(ctx: click.Context, name: str):

--- a/src/hdx_cli/cli_interface/function/commands.py
+++ b/src/hdx_cli/cli_interface/function/commands.py
@@ -13,8 +13,6 @@ from hdx_cli.library_api.common.logging import get_logger
 from hdx_cli.library_api.utility.decorators import (
     ensure_logged_in,
     no_rollback_option,
-    report_error_and_exit,
-    skip_group_logic_on_help,
     target_cluster_options,
 )
 from hdx_cli.library_api.utility.file_handling import read_json_from_file
@@ -39,8 +37,6 @@ logger = get_logger()
     default=None,
 )
 @click.pass_context
-@skip_group_logic_on_help
-@report_error_and_exit(exctype=Exception)
 @ensure_logged_in
 def function(ctx: click.Context, project_name: str, function_name: str):
     """This group of commands allows creating, listing, showing, deleting,
@@ -78,7 +74,6 @@ def function(ctx: click.Context, project_name: str, function_name: str):
 )
 @click.option("--inline-sql", "-s", help="Use inline sql in the command-line", default=None)
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def create(ctx: click.Context, resource_name: str, sql_from_file: str, inline_sql: str):
     """A {resource} can be created either from an inline SQL string
     or from a JSON file containing the {resource} definition.
@@ -119,7 +114,6 @@ def create(ctx: click.Context, resource_name: str, sql_from_file: str, inline_sq
 @target_cluster_options
 @no_rollback_option
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def migrate(
     ctx: click.Context,
     target_project_name: str,

--- a/src/hdx_cli/cli_interface/integration/commands.py
+++ b/src/hdx_cli/cli_interface/integration/commands.py
@@ -8,7 +8,7 @@ from hdx_cli.cli_interface.common.click_extensions import HdxCommand, HdxGroup
 from hdx_cli.cli_interface.common.undecorated_click_commands import basic_create, basic_transform
 from hdx_cli.library_api.common import rest_operations as rest_ops
 from hdx_cli.library_api.common.logging import get_logger
-from hdx_cli.library_api.utility.decorators import ensure_logged_in, report_error_and_exit
+from hdx_cli.library_api.utility.decorators import ensure_logged_in
 from hdx_cli.models import ProfileLoadContext, ProfileUserContext
 
 logger = get_logger()
@@ -34,7 +34,6 @@ def integration(ctx: click.Context):
 
 
 @click.group(cls=HdxGroup)
-@report_error_and_exit(exctype=Exception)
 @click.pass_context
 @ensure_logged_in
 def transform(ctx: click.Context):
@@ -64,7 +63,6 @@ def _github_list(ctx: click.Context):
 
 @click.command(cls=HdxCommand, name="list")
 @click.pass_context
-# @report_error_and_exit(exctype=Exception)
 def list_(ctx: click.Context):
     """List available integration {resource_plural}.
 
@@ -115,7 +113,6 @@ def _basic_show(ctx: click.Context, transform_name: str, indent: bool = False):
 )
 @click.option("--table", "table_name", required=True, help="The table to apply the transform to.")
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def apply(
     ctx: click.Context,
     integration_transform_name: str,
@@ -158,7 +155,6 @@ def apply(
     help="Number of spaces for indentation in the output.",
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def show(ctx: click.Context, resource_name: str, indent: bool):
     """Show the definition of a public integration {resource}.
 

--- a/src/hdx_cli/cli_interface/job/alter/commands.py
+++ b/src/hdx_cli/cli_interface/job/alter/commands.py
@@ -5,13 +5,16 @@ from rich.console import Console
 from rich.table import Table
 
 from hdx_cli.cli_interface.common.cached_operations import find_alter_jobs
-from hdx_cli.cli_interface.common.click_extensions import HdxGroup, HdxCommand
-from hdx_cli.cli_interface.common.undecorated_click_commands import basic_create, basic_show, basic_list
+from hdx_cli.cli_interface.common.click_extensions import HdxCommand, HdxGroup
 from hdx_cli.cli_interface.common.rest_operations import delete as command_delete
 from hdx_cli.cli_interface.common.rest_operations import show as command_show
+from hdx_cli.cli_interface.common.undecorated_click_commands import (
+    basic_create,
+    basic_list,
+    basic_show,
+)
 from hdx_cli.library_api.common.exceptions import LogicException
 from hdx_cli.library_api.common.logging import get_logger
-from hdx_cli.library_api.utility.decorators import report_error_and_exit
 from hdx_cli.library_api.utility.functions import heuristically_get_resource_kind
 from hdx_cli.models import ProfileUserContext
 
@@ -27,7 +30,6 @@ console = Console()
     help="Perform an operation on the passed job name.",
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def alter(ctx: click.Context, alter_name: str):
     """Manage alter jobs."""
     user_profile = ctx.parent.obj["usercontext"]
@@ -38,7 +40,6 @@ def alter(ctx: click.Context, alter_name: str):
 
 @alter.group(cls=HdxGroup)
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def create(ctx: click.Context):
     """Create a new alter job."""
     user_profile = ctx.parent.obj["usercontext"]
@@ -56,7 +57,6 @@ def create(ctx: click.Context):
 @click.option("--value", required=True, help="The new value for the column.")
 @click.option("--where", required=True, help="The WHERE clause for the update operation.")
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def create_update(ctx: click.Context, table: str, column: str, value, where: str):
     """Create a job to update specific rows in a table.
 
@@ -73,12 +73,9 @@ def create_update(ctx: click.Context, table: str, column: str, value, where: str
 
 
 @create.command(cls=HdxCommand, name="delete")
-@click.option(
-    "--table", required=True, help="The table to alter, e.g., my_proj.my_tbl."
-)
+@click.option("--table", required=True, help="The table to alter, e.g., my_proj.my_tbl.")
 @click.option("--where", required=True, help="The WHERE clause for the delete operation.")
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def create_delete(ctx: click.Context, table: str, where: str):
     """Create a job to delete specific rows from a table.
 
@@ -99,7 +96,6 @@ def create_delete(ctx: click.Context, table: str, where: str):
 @click.option("--project", "project_name", default=None, help="Filter alter jobs by project name.")
 @click.option("--table", "table_name", default=None, help="Filter alter jobs by table name.")
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def list_(ctx: click.Context, status: str, project_name: str, table_name: str):
     """List all alter jobs.
 
@@ -115,7 +111,6 @@ def list_(ctx: click.Context, status: str, project_name: str, table_name: str):
 @alter.command(cls=HdxCommand)
 @click.argument("job_name", required=False)
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def commit(ctx: click.Context, job_name: str):
     """Commit changes made by an alter job.
 
@@ -133,7 +128,6 @@ def commit(ctx: click.Context, job_name: str):
 @alter.command(cls=HdxCommand)
 @click.argument("job_name", required=False)
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def cancel(ctx: click.Context, job_name: str):
     """Cancel an ongoing alter job.
 
@@ -151,7 +145,6 @@ def cancel(ctx: click.Context, job_name: str):
 @alter.command(cls=HdxCommand)
 @click.argument("job_name", required=False)
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def retry(ctx: click.Context, job_name: str):
     """Retry a failed alter job.
 
@@ -169,7 +162,6 @@ def retry(ctx: click.Context, job_name: str):
 @alter.command(cls=HdxCommand)
 @click.argument("job_name", required=False)
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def verify(ctx: click.Context, job_name: str):
     """Verify the status of an alter job.
 

--- a/src/hdx_cli/cli_interface/job/batch/commands.py
+++ b/src/hdx_cli/cli_interface/job/batch/commands.py
@@ -4,15 +4,14 @@ import click
 from rich.console import Console
 from rich.table import Table
 
-from hdx_cli.cli_interface.common.cached_operations import find_transforms, find_batch_jobs
-from hdx_cli.cli_interface.common.click_extensions import HdxGroup, HdxCommand
-from hdx_cli.cli_interface.common.undecorated_click_commands import basic_create, basic_show
+from hdx_cli.cli_interface.common.cached_operations import find_batch_jobs, find_transforms
+from hdx_cli.cli_interface.common.click_extensions import HdxCommand, HdxGroup
 from hdx_cli.cli_interface.common.misc_operations import settings as command_settings
 from hdx_cli.cli_interface.common.rest_operations import delete as command_delete
 from hdx_cli.cli_interface.common.rest_operations import show as command_show
+from hdx_cli.cli_interface.common.undecorated_click_commands import basic_create, basic_show
 from hdx_cli.library_api.common.exceptions import ResourceNotFoundException
 from hdx_cli.library_api.common.logging import get_logger
-from hdx_cli.library_api.utility.decorators import report_error_and_exit
 from hdx_cli.library_api.utility.file_handling import read_json_from_file
 from hdx_cli.models import ProfileUserContext
 
@@ -42,34 +41,22 @@ def batch(ctx: click.Context, batch_name: str):
 
 @batch.command(cls=HdxCommand)
 @click.argument("job_name")
-@click.argument(
-    "settings_file_path",
-    type=click.Path(exists=True, readable=True)
-)
-@click.option(
-    "--project",
-    "project_name",
-    help="Override the project for the ingest job."
-)
-@click.option(
-    "--table",
-    "table_name",
-    help="Override the table for the ingest job."
-)
+@click.argument("settings_file_path", type=click.Path(exists=True, readable=True))
+@click.option("--project", "project_name", help="Override the project for the ingest job.")
+@click.option("--table", "table_name", help="Override the table for the ingest job.")
 @click.option(
     "--transform",
     "transform_name",
     help="Override the transform to use. Defaults to the table's default transform.",
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def ingest(
     ctx: click.Context,
     job_name: str,
     settings_file_path: str,
     project_name: str,
     table_name: str,
-    transform_name: str
+    transform_name: str,
 ):
     """Create an ingest job from a settings file.
 
@@ -94,17 +81,23 @@ def ingest(
     if project_name and table_name:
         body["settings"]["source"]["table"] = f"{project_name}.{table_name}"
     elif project_name or table_name:
-        raise click.BadOptionUsage("project", "Both --project and --table must be provided together.")
+        raise click.BadOptionUsage(
+            "project", "Both --project and --table must be provided together."
+        )
 
     # Determine the transform to use
-    final_project, final_table = body["settings"]["source"]["table"].split('.')
-    ProfileUserContext.update_context(user_profile, projectname=final_project, tablename=final_table)
+    final_project, final_table = body["settings"]["source"]["table"].split(".")
+    ProfileUserContext.update_context(
+        user_profile, projectname=final_project, tablename=final_table
+    )
 
     if not transform_name:
         if not (transform_name := body["settings"]["source"].get("transform")):
             transforms_list = find_transforms(user_profile)
             try:
-                transform_name = [t["name"] for t in transforms_list if t["settings"]["is_default"]][0]
+                transform_name = [
+                    t["name"] for t in transforms_list if t["settings"]["is_default"]
+                ][0]
             except (IndexError, KeyError) as exc:
                 raise ResourceNotFoundException(
                     "No default transform found for the table and no --transform was provided."
@@ -117,7 +110,6 @@ def ingest(
 
 @batch.command(cls=HdxCommand, name="list")
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def list_(ctx: click.Context):
     """List all batch jobs.
 
@@ -149,7 +141,6 @@ def list_(ctx: click.Context):
 @batch.command(cls=HdxCommand)
 @click.argument("job_name")
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def cancel(ctx: click.Context, job_name: str):
     """Cancel a running batch job.
 
@@ -169,7 +160,6 @@ def cancel(ctx: click.Context, job_name: str):
 @batch.command(cls=HdxCommand)
 @click.argument("job_name")
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def retry(ctx, job_name: str):
     """Retry a failed batch job.
 

--- a/src/hdx_cli/cli_interface/job/commands.py
+++ b/src/hdx_cli/cli_interface/job/commands.py
@@ -2,20 +2,17 @@ import click
 
 from hdx_cli.cli_interface.common.undecorated_click_commands import basic_create
 from hdx_cli.library_api.common.logging import get_logger
-from hdx_cli.library_api.utility.decorators import (
-    report_error_and_exit,
-    ensure_logged_in,
-)
+from hdx_cli.library_api.utility.decorators import ensure_logged_in
+
+from ..common.click_extensions import HdxCommand, HdxGroup
 from .alter.commands import alter as alter_command
 from .batch.commands import batch as batch_command
-from ..common.click_extensions import HdxGroup, HdxCommand
 
 logger = get_logger()
 
 
 @click.group(cls=HdxGroup)
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 @ensure_logged_in
 def job(ctx: click.Context):
     """Manage batch and alter jobs."""
@@ -33,14 +30,10 @@ def job(ctx: click.Context):
     help="Skip confirmation prompt.",
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def purgejobs(ctx: click.Context, yes: bool):
     """Purge all batch jobs in the organization."""
     if not yes:
-        click.confirm(
-            "Are you sure you want to purge all jobs?",
-            abort=True
-        )
+        click.confirm("Are you sure you want to purge all jobs?", abort=True)
 
     user_profile = ctx.parent.obj["usercontext"]
     org_id = user_profile.org_id

--- a/src/hdx_cli/cli_interface/migrate/commands.py
+++ b/src/hdx_cli/cli_interface/migrate/commands.py
@@ -7,12 +7,12 @@ from hdx_cli.cli_interface.common.click_extensions import HdxCommand
 from hdx_cli.cli_interface.migrate.data import migrate_data
 from hdx_cli.cli_interface.migrate.helpers import MigrationData, get_catalog
 from hdx_cli.cli_interface.migrate.rc.rc_manager import RcloneAPIConfig
-from hdx_cli.cli_interface.migrate.resources import get_resources, create_resources
+from hdx_cli.cli_interface.migrate.resources import create_resources, get_resources
 from hdx_cli.cli_interface.migrate.validator import validations
 from hdx_cli.config.profile_settings import is_valid_hostname
 from hdx_cli.library_api.common.exceptions import InvalidHostnameException
 from hdx_cli.library_api.common.logging import get_logger
-from hdx_cli.library_api.utility.decorators import report_error_and_exit, ensure_logged_in
+from hdx_cli.library_api.utility.decorators import ensure_logged_in
 
 logger = get_logger()
 
@@ -22,14 +22,12 @@ class CustomDateTime(click.Option):
         return ", ".join(self.opts), self.help
 
 
-@report_error_and_exit(exctype=Exception)
 def validate_tablename_format(ctx, param, value):
     if value is None or len(value.split(".")) != 2:
         raise click.BadParameter(f"'{value}' is not in the 'project_name.table_name' format.")
     return value
 
 
-@report_error_and_exit(exctype=Exception)
 def validate_hostname(ctx, params, hostname: str) -> str:
     if hostname and not is_valid_hostname(hostname):
         raise InvalidHostnameException("Invalid host name format.")
@@ -158,7 +156,6 @@ def validate_hostname(ctx, params, hostname: str) -> str:
     hidden=True,
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 @ensure_logged_in
 def migrate(
     ctx: click.Context,
@@ -236,7 +233,9 @@ def migrate(
     """
     source_profile = ctx.parent.obj["usercontext"]
     has_target_profile = target_profile_name is not None
-    has_all_cluster_options = all([target_hostname, target_username, target_password, target_uri_scheme])
+    has_all_cluster_options = all(
+        [target_hostname, target_username, target_password, target_uri_scheme]
+    )
 
     if not has_target_profile and not has_all_cluster_options:
         raise click.BadParameter(
@@ -317,7 +316,7 @@ def migrate(
             source_data,
             reuse_partitions,
             migrate_functions=with_functions,
-            migrate_dictionaries=with_dictionaries
+            migrate_dictionaries=with_dictionaries,
         )
     if only != "resources":
         migrate_data(

--- a/src/hdx_cli/cli_interface/pool/commands.py
+++ b/src/hdx_cli/cli_interface/pool/commands.py
@@ -1,13 +1,13 @@
 import click
 
-from hdx_cli.cli_interface.common.click_extensions import HdxGroup, HdxCommand
-from hdx_cli.cli_interface.common.undecorated_click_commands import basic_create
+from hdx_cli.cli_interface.common.click_extensions import HdxCommand, HdxGroup
 from hdx_cli.cli_interface.common.misc_operations import settings as command_settings
 from hdx_cli.cli_interface.common.rest_operations import delete as command_delete
 from hdx_cli.cli_interface.common.rest_operations import list_ as command_list
 from hdx_cli.cli_interface.common.rest_operations import show as command_show
+from hdx_cli.cli_interface.common.undecorated_click_commands import basic_create
 from hdx_cli.library_api.common.logging import get_logger
-from hdx_cli.library_api.utility.decorators import report_error_and_exit, ensure_logged_in
+from hdx_cli.library_api.utility.decorators import ensure_logged_in
 from hdx_cli.models import ProfileUserContext
 
 logger = get_logger()
@@ -21,7 +21,6 @@ logger = get_logger()
     help="Use or override pool set in the profile.",
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 @ensure_logged_in
 def pool(ctx: click.Context, pool_name: str):
     """Commands to create, list, and manage resource pools for
@@ -85,7 +84,6 @@ def _build_pool_payload(
     default=0.5,
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def create(
     ctx: click.Context,
     pool_name: str,

--- a/src/hdx_cli/cli_interface/profile/commands.py
+++ b/src/hdx_cli/cli_interface/profile/commands.py
@@ -6,24 +6,21 @@ from hdx_cli.auth.session import delete_session_file
 from hdx_cli.cli_interface.common.click_extensions import HdxCommand, HdxGroup
 from hdx_cli.cli_interface.profile.utils import get_profile_from_context
 from hdx_cli.config.profile_settings import (
-    profile_config_from_standard_input, 
-    save_profile_config,
-    delete_profile_config, 
-    is_valid_scheme, 
+    delete_profile_config,
     is_valid_hostname,
+    is_valid_scheme,
+    profile_config_from_standard_input,
+    save_profile_config,
 )
 from hdx_cli.library_api.common.exceptions import (
-    InvalidHostnameException,
-    InvalidSchemeException, 
-    ProfileExistsException, 
     HdxCliException,
+    InvalidHostnameException,
+    InvalidSchemeException,
+    ProfileExistsException,
 )
 from hdx_cli.library_api.common.logging import get_logger
-from hdx_cli.library_api.utility.decorators import (
-    report_error_and_exit, 
-    with_profiles_context,
-)
-from hdx_cli.models import ProfileLoadContext, ProfileUserContext, BasicProfileConfig
+from hdx_cli.library_api.utility.decorators import with_profiles_context
+from hdx_cli.models import BasicProfileConfig, ProfileLoadContext, ProfileUserContext
 
 logger = get_logger()
 console = Console()
@@ -39,7 +36,6 @@ def profile(ctx: click.Context):
 @click.command(cls=HdxCommand, name="show")
 @click.argument("profile_name")
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 @with_profiles_context
 def profile_show(
     ctx: click.Context,
@@ -68,7 +64,6 @@ def profile_show(
 
 @click.command(cls=HdxCommand, name="list")
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 @with_profiles_context
 def profile_list(ctx: click.Context, profile_context, config_profiles):
     """List all available {resource_plural}.
@@ -91,7 +86,6 @@ def profile_list(ctx: click.Context, profile_context, config_profiles):
 @click.command(cls=HdxCommand, name="edit")
 @click.argument("profile_name")
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 @with_profiles_context
 def profile_edit(
     ctx: click.Context,
@@ -137,7 +131,6 @@ def profile_edit(
     help="Protocol for the connection.",
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 @with_profiles_context
 def profile_add(
     ctx: click.Context,
@@ -161,7 +154,7 @@ def profile_add(
     """
     if profile_name in config_profiles:
         raise ProfileExistsException(f"Profile '{profile_name}' already exists.")
-    
+
     if hostname and scheme:
         if not is_valid_hostname(hostname):
             raise InvalidHostnameException("Invalid host name format.")
@@ -197,7 +190,6 @@ def profile_add(
     help="Skip confirmation prompt.",
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 @with_profiles_context
 def profile_delete(
     ctx: click.Context,
@@ -237,7 +229,6 @@ def profile_delete(
     help="Skip confirmation prompt.",
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 @with_profiles_context
 def profile_logout(
     ctx: click.Context,

--- a/src/hdx_cli/cli_interface/project/commands.py
+++ b/src/hdx_cli/cli_interface/project/commands.py
@@ -1,20 +1,19 @@
 import click
 
-from hdx_cli.cli_interface.common.click_extensions import HdxGroup, HdxCommand
+from hdx_cli.cli_interface.common.click_extensions import HdxCommand, HdxGroup
 from hdx_cli.cli_interface.common.migration.resource_migrations import migrate_resource_config
-from hdx_cli.cli_interface.common.undecorated_click_commands import basic_create
 from hdx_cli.cli_interface.common.misc_operations import settings as command_settings
 from hdx_cli.cli_interface.common.rest_operations import activity as command_activity
 from hdx_cli.cli_interface.common.rest_operations import delete as command_delete
 from hdx_cli.cli_interface.common.rest_operations import list_ as command_list
 from hdx_cli.cli_interface.common.rest_operations import show as command_show
 from hdx_cli.cli_interface.common.rest_operations import stats as command_stats
+from hdx_cli.cli_interface.common.undecorated_click_commands import basic_create
 from hdx_cli.library_api.common.logging import get_logger
 from hdx_cli.library_api.utility.decorators import (
-    report_error_and_exit,
     ensure_logged_in,
-    target_cluster_options,
     no_rollback_option,
+    target_cluster_options,
 )
 from hdx_cli.models import ProfileUserContext
 
@@ -30,7 +29,6 @@ logger = get_logger()
     help="Use or override project set in the profile.",
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 @ensure_logged_in
 def project(ctx: click.Context, project_name: str):
     """Provides commands to create, list, show, delete, and migrate
@@ -45,7 +43,6 @@ def project(ctx: click.Context, project_name: str):
 @click.command(cls=HdxCommand)
 @click.argument("resource_name")
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def create(ctx: click.Context, resource_name: str):
     """Creates a new, empty {resource} in your Hydrolix cluster.
 
@@ -86,7 +83,6 @@ def create(ctx: click.Context, resource_name: str):
     help="Migrate functions associated with the project.",
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def migrate(
     ctx: click.Context,
     new_project_name: str,
@@ -129,12 +125,19 @@ def migrate(
     source_profile = ctx.parent.obj["usercontext"]
 
     if not source_profile.projectname:
-        raise click.BadParameter("A source project must be specified with the --project option.",
-                                 param_hint="--project")
+        raise click.BadParameter(
+            "A source project must be specified with the --project option.", param_hint="--project"
+        )
 
     has_target_profile = target_profile is not None
-    has_all_cluster_options = all([target_cluster_hostname, target_cluster_username,
-                                   target_cluster_password, target_cluster_uri_scheme])
+    has_all_cluster_options = all(
+        [
+            target_cluster_hostname,
+            target_cluster_username,
+            target_cluster_password,
+            target_cluster_uri_scheme,
+        ]
+    )
     if not has_target_profile and not has_all_cluster_options:
         raise click.BadParameter(
             "Either provide a --target-profile or all four target cluster options."

--- a/src/hdx_cli/cli_interface/query_option/commands.py
+++ b/src/hdx_cli/cli_interface/query_option/commands.py
@@ -1,20 +1,20 @@
 from typing import Optional
 from urllib.parse import urlparse
+
+import click
 from rich.console import Console
 from rich.table import Table
 
-import click
-
-from hdx_cli.cli_interface.common.click_extensions import HdxGroup, HdxCommand
+from hdx_cli.cli_interface.common.click_extensions import HdxCommand, HdxGroup
 from hdx_cli.cli_interface.common.undecorated_click_commands import (
     basic_get,
-    basic_update,
     basic_options,
+    basic_update,
 )
 from hdx_cli.library_api.common.exceptions import QueryOptionNotFound
 from hdx_cli.library_api.common.generic_resource import access_resource_detailed
 from hdx_cli.library_api.common.logging import get_logger
-from hdx_cli.library_api.utility.decorators import report_error_and_exit, ensure_logged_in
+from hdx_cli.library_api.utility.decorators import ensure_logged_in
 from hdx_cli.library_api.utility.file_handling import read_json_from_file
 from hdx_cli.models import ProfileUserContext
 
@@ -23,10 +23,10 @@ console = Console()
 
 
 def _build_resource_path(
-        profile: ProfileUserContext,
-        org_id: str,
-        project_name: Optional[str],
-        table_name: Optional[str],
+    profile: ProfileUserContext,
+    org_id: str,
+    project_name: Optional[str],
+    table_name: Optional[str],
 ) -> str:
     """Build the resource path based on the provided scope."""
     # Table-level scope (most specific)
@@ -39,9 +39,7 @@ def _build_resource_path(
 
     # Project-level scope
     elif project_name:
-        _, resource_url = access_resource_detailed(
-            profile, [("projects", project_name)]
-        )
+        _, resource_url = access_resource_detailed(profile, [("projects", project_name)])
         base_path = urlparse(resource_url).path
         return f"{base_path}query_options/"
 
@@ -53,7 +51,6 @@ def _build_resource_path(
 @click.option("--project", "project_name", help="Target a specific project by name.")
 @click.option("--table", "table_name", help="Target a specific table by name.")
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 @ensure_logged_in
 def query_option(ctx: click.Context, project_name: Optional[str], table_name: Optional[str]):
     """Manage default query options.
@@ -95,7 +92,6 @@ def query_option(ctx: click.Context, project_name: Optional[str], table_name: Op
     help="Set query options from a JSON file.",
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def set_(ctx: click.Context, options_to_set: tuple, from_file_path: str):
     """Set one or more query options for the specified scope.
     Options can be set individually using `--option`,
@@ -115,9 +111,7 @@ def set_(ctx: click.Context, options_to_set: tuple, from_file_path: str):
       {full_command_prefix} set --from-file ./options.json
     """
     if not options_to_set and not from_file_path:
-        raise click.BadParameter(
-         "Provide at least one --option or use the --from-file flag."
-        )
+        raise click.BadParameter("Provide at least one --option or use the --from-file flag.")
 
     if options_to_set and from_file_path:
         raise click.BadParameter("Cannot use arguments and --from-file simultaneously.")
@@ -158,7 +152,6 @@ def set_(ctx: click.Context, options_to_set: tuple, from_file_path: str):
 @click.argument("query_option_name", required=False)
 @click.option("--all", "all_options", is_flag=True, help="Unset all query options for the scope.")
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def unset(ctx: click.Context, query_option_name: Optional[str], all_options: bool):
     """Unset one or more query options for the specified scope.
     Unset a single option by name, or unset all options
@@ -202,7 +195,6 @@ def unset(ctx: click.Context, query_option_name: Optional[str], all_options: boo
 
 @click.command(cls=HdxCommand, name="list")
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def list_(ctx: click.Context):
     """List the configured query options for the current scope.
 
@@ -241,7 +233,12 @@ def list_(ctx: click.Context):
 def _available_query_options(profile: ProfileUserContext, resource_path: str) -> dict:
     """Fetch available query options via OPTIONS request."""
     response = basic_options(profile, resource_path, action="PUT")
-    return response.get("settings", {}).get("children", {}).get("default_query_options", {}).get("children", {})
+    return (
+        response.get("settings", {})
+        .get("children", {})
+        .get("default_query_options", {})
+        .get("children", {})
+    )
 
 
 query_option.add_command(set_)

--- a/src/hdx_cli/cli_interface/resource_summary/commands.py
+++ b/src/hdx_cli/cli_interface/resource_summary/commands.py
@@ -9,7 +9,7 @@ from hdx_cli.cli_interface.common.click_extensions import HdxCommand
 from hdx_cli.cli_interface.common.undecorated_click_commands import basic_get
 from hdx_cli.library_api.common.exceptions import ConfigurationNotFoundException
 from hdx_cli.library_api.common.logging import get_logger
-from hdx_cli.library_api.utility.decorators import report_error_and_exit, ensure_logged_in
+from hdx_cli.library_api.utility.decorators import ensure_logged_in
 from hdx_cli.models import ProfileUserContext
 
 logger = get_logger()
@@ -23,7 +23,7 @@ def get_resource_count(profile: ProfileUserContext, path: str) -> int:
         return 0
 
     if isinstance(response_data, dict):
-        return response_data.get('count', 0)
+        return response_data.get("count", 0)
 
     if isinstance(response_data, list):
         return len(response_data)
@@ -34,7 +34,6 @@ def get_resource_count(profile: ProfileUserContext, path: str) -> int:
 
 @click.command(cls=HdxCommand, name="resource-summary")
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 @ensure_logged_in
 def resource_summary(ctx: click.Context):
     """Summarize the count of all resources in the organization.
@@ -78,12 +77,8 @@ def _resource_summary(profile: ProfileUserContext) -> Optional[dict]:
     final_counts["Users & SA"] = get_resource_count(profile, "/config/v1/users/")
     final_counts["Roles"] = get_resource_count(profile, "/config/v1/roles/")
 
-    alter_jobs_count = get_resource_count(
-        profile, f"/config/v1/orgs/{profile.org_id}/jobs/alter/"
-    )
-    batch_jobs_count = get_resource_count(
-        profile, f"/config/v1/orgs/{profile.org_id}/jobs/batch/"
-    )
+    alter_jobs_count = get_resource_count(profile, f"/config/v1/orgs/{profile.org_id}/jobs/alter/")
+    batch_jobs_count = get_resource_count(profile, f"/config/v1/orgs/{profile.org_id}/jobs/batch/")
     final_counts["Jobs"] = alter_jobs_count + batch_jobs_count
 
     return final_counts

--- a/src/hdx_cli/cli_interface/role/commands.py
+++ b/src/hdx_cli/cli_interface/role/commands.py
@@ -2,31 +2,32 @@ import json
 import uuid
 
 import click
-from rich.console import Console
 from rich.columns import Columns
+from rich.console import Console
 from rich.table import Table
 
-from hdx_cli.cli_interface.common.click_extensions import HdxGroup, HdxCommand
-from hdx_cli.cli_interface.common.cached_operations import find_users, find_permissions
+from hdx_cli.cli_interface.common.cached_operations import find_permissions, find_users
+from hdx_cli.cli_interface.common.click_extensions import HdxCommand, HdxGroup
+from hdx_cli.cli_interface.common.rest_operations import delete as command_delete
+from hdx_cli.cli_interface.common.rest_operations import list_ as command_list
+from hdx_cli.cli_interface.common.rest_operations import show as command_show
 from hdx_cli.cli_interface.common.undecorated_click_commands import (
     basic_create,
     basic_show,
     basic_update,
 )
-from hdx_cli.cli_interface.common.rest_operations import delete as command_delete
-from hdx_cli.cli_interface.common.rest_operations import list_ as command_list
-from hdx_cli.cli_interface.common.rest_operations import show as command_show
+from hdx_cli.library_api.common.exceptions import LogicException, ResourceNotFoundException
+from hdx_cli.library_api.common.logging import get_logger
+from hdx_cli.library_api.utility.decorators import ensure_logged_in
+from hdx_cli.models import ProfileUserContext
+
 from .utils import (
-    get_available_scope_type_list,
-    get_role_data_from_standard_input,
     Policy,
     Role,
+    get_available_scope_type_list,
+    get_role_data_from_standard_input,
     modify_role_data_from_standard_input,
 )
-from hdx_cli.library_api.common.exceptions import ResourceNotFoundException, LogicException
-from hdx_cli.library_api.common.logging import get_logger
-from hdx_cli.library_api.utility.decorators import report_error_and_exit, ensure_logged_in
-from hdx_cli.models import ProfileUserContext
 
 logger = get_logger()
 console = Console()
@@ -41,7 +42,6 @@ console = Console()
     help="Perform operation on the passed role.",
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 @ensure_logged_in
 def role(ctx: click.Context, role_name: str):
     """Commands to create, edit, and manage user roles and
@@ -110,7 +110,6 @@ def validate_scope_type(ctx, param, value):
     help="Enter interactive mode to be guided through role creation.",
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def create(
     ctx: click.Context,
     resource_name: str,
@@ -147,9 +146,13 @@ def create(
         role_obj = get_role_data_from_standard_input(profile, resource_path, resource_name)
     elif permissions:
         if scope_type and not scope_id:
-            raise click.BadOptionUsage("scope_id", "--scope-id is required when --scope-type is used.")
+            raise click.BadOptionUsage(
+                "scope_id", "--scope-id is required when --scope-type is used."
+            )
         if scope_id and not scope_type:
-            raise click.BadOptionUsage("scope_type", "--scope-type is required when --scope-id is used.")
+            raise click.BadOptionUsage(
+                "scope_type", "--scope-type is required when --scope-id is used."
+            )
         policy_obj = Policy(scope_type=scope_type, scope_id=scope_id, permissions=list(permissions))
         role_obj = Role(name=resource_name, policies=[policy_obj])
     else:
@@ -174,7 +177,6 @@ def create(
 @click.command(cls=HdxCommand)
 @click.argument("resource_name")
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def edit(ctx: click.Context, resource_name: str):
     """Modify an existing {resource} interactively.
 
@@ -217,7 +219,6 @@ def edit(ctx: click.Context, resource_name: str):
     help="Specify users to add to a role (can be used multiple times).",
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def add_user(ctx: click.Context, resource_name: str, users):
     """Add one or more users to a {resource}.
 
@@ -243,7 +244,6 @@ def add_user(ctx: click.Context, resource_name: str, users):
     help="Specify users to remove from a role (can be used multiple times).",
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def remove_user(ctx: click.Context, resource_name: str, users):
     """Remove one or more users from a {resource}.
 
@@ -269,7 +269,6 @@ def remove_user(ctx: click.Context, resource_name: str, users):
     help="Filter the permissions by a specific scope type.",
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def list_permissions(ctx: click.Context, scope_type: str):
     """Lists all available permissions that can be assigned
     to a role, optionally filtered by a scope type.

--- a/src/hdx_cli/cli_interface/row_policy/commands.py
+++ b/src/hdx_cli/cli_interface/row_policy/commands.py
@@ -16,11 +16,7 @@ from hdx_cli.cli_interface.common.undecorated_click_commands import (
 )
 from hdx_cli.library_api.common.exceptions import CommandLineException, LogicException
 from hdx_cli.library_api.common.logging import get_logger
-from hdx_cli.library_api.utility.decorators import (
-    ensure_logged_in,
-    report_error_and_exit,
-    skip_group_logic_on_help,
-)
+from hdx_cli.library_api.utility.decorators import ensure_logged_in
 from hdx_cli.models import ProfileUserContext
 
 logger = get_logger()
@@ -49,8 +45,6 @@ logger = get_logger()
     default=None,
 )
 @click.pass_context
-@skip_group_logic_on_help
-@report_error_and_exit(exctype=Exception)
 @ensure_logged_in
 def row_policy(ctx: click.Context, project_name: str, table_name: str, row_policy_name: str):
     """Manages Row-Level security policies for tables.
@@ -92,7 +86,6 @@ def row_policy(ctx: click.Context, project_name: str, table_name: str, row_polic
     help="Role to associate with this policy. Can be specified multiple times.",
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def create(
     ctx: click.Context,
     resource_name: str,
@@ -129,7 +122,6 @@ def create(
 
 @click.command(cls=HdxCommand, name="list")
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def list_(ctx: click.Context):
     """Lists all {resource_plural} for a given table.
     Displays a summary of all {resource_plural}, including their name, filter
@@ -204,7 +196,6 @@ def _role_operation(ctx: click.Context, policy_name: str, roles: list[str], oper
     help="Role to add. Can be specified multiple times.",
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def add_role(ctx: click.Context, resource_name: str, roles: list[str]):
     """Adds one or more roles to an existing {resource}.
     This command associates roles with a {resource}, granting the
@@ -233,7 +224,6 @@ def add_role(ctx: click.Context, resource_name: str, roles: list[str]):
     help="Role to remove. Can be specified multiple times.",
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def remove_role(ctx: click.Context, resource_name: str, roles: list[str]):
     """Removes one or more roles from an existing {resource}.
     This command disassociates roles from a {resource}, revoking the

--- a/src/hdx_cli/cli_interface/set/commands.py
+++ b/src/hdx_cli/cli_interface/set/commands.py
@@ -3,7 +3,7 @@ import click
 from hdx_cli.cli_interface.common.click_extensions import HdxCommand
 from hdx_cli.config.profile_settings import load_static_profile_config, save_profile_config
 from hdx_cli.library_api.common.logging import get_logger
-from hdx_cli.library_api.utility.decorators import report_error_and_exit, with_profiles_context
+from hdx_cli.library_api.utility.decorators import with_profiles_context
 from hdx_cli.models import ProfileLoadContext, ProfileUserContext
 
 logger = get_logger()
@@ -13,7 +13,6 @@ logger = get_logger()
 @click.argument("project_name", metavar="PROJECT_NAME", required=True)
 @click.argument("table_name", metavar="TABLE_NAME", required=False, default=None)
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 @with_profiles_context
 def set_context(
     ctx: click.Context,
@@ -47,7 +46,6 @@ def set_context(
 
 @click.command(cls=HdxCommand, name="unset")
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 @with_profiles_context
 def unset_context(
     ctx: click.Context,

--- a/src/hdx_cli/cli_interface/shadow/commands.py
+++ b/src/hdx_cli/cli_interface/shadow/commands.py
@@ -17,8 +17,6 @@ from hdx_cli.library_api.common.logging import get_logger
 from hdx_cli.library_api.utility.decorators import (
     dynamic_confirmation_prompt,
     ensure_logged_in,
-    report_error_and_exit,
-    skip_group_logic_on_help,
 )
 from hdx_cli.library_api.utility.file_handling import read_json_from_file
 from hdx_cli.models import ProfileUserContext
@@ -35,8 +33,6 @@ logger = get_logger()
     default=None,
 )
 @click.pass_context
-@skip_group_logic_on_help
-@report_error_and_exit(exctype=Exception)
 @ensure_logged_in
 def shadow(ctx: click.Context, project_name: str):
     """Shadow tables allow safe testing of transform changes by
@@ -107,7 +103,6 @@ def shadow(ctx: click.Context, project_name: str):
     help="Name of the transform for the shadow table. Default: shadow_ + 'source-transform-name'.",
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def create(
     ctx: click.Context,
     transform_settings_path: str,
@@ -197,7 +192,6 @@ _confirmation_prompt = partial(
     default=False,
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def delete(ctx: click.Context, resource_name: str, disable_confirmation_prompt: bool):
     """Delete a {resource} table.
 
@@ -240,7 +234,6 @@ def delete(ctx: click.Context, resource_name: str, disable_confirmation_prompt: 
     help="Percentage of the original data to be ingested in the shadow table.",
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def start(ctx: click.Context, resource_name: str, sample_rate: int):
     """Start or update sampling for a shadow table, setting the
     specified sampling rate on the source transform.
@@ -267,7 +260,6 @@ def start(ctx: click.Context, resource_name: str, sample_rate: int):
 @click.command(cls=HdxCommand)
 @click.argument("resource_name", required=True)
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def stop(ctx: click.Context, resource_name: str):
     """Stop sampling for a shadow table, setting the
     sampling rate on the source transform to 0.

--- a/src/hdx_cli/cli_interface/sources/common_commands.py
+++ b/src/hdx_cli/cli_interface/sources/common_commands.py
@@ -7,7 +7,6 @@ from hdx_cli.cli_interface.common.undecorated_click_commands import basic_create
 from hdx_cli.library_api.common.exceptions import HdxCliException
 from hdx_cli.library_api.common.generic_resource import access_resource_detailed
 from hdx_cli.library_api.common.logging import get_logger
-from hdx_cli.library_api.utility.decorators import report_error_and_exit
 from hdx_cli.library_api.utility.file_handling import read_json_from_file
 
 logger = get_logger()
@@ -39,7 +38,6 @@ def any_source_impl(ctx: click.Context, source_name: str):
     type=click.Path(exists=True, readable=True),
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def create(ctx: click.Context, settings_filename: str, resource_name: str):
     """Creates a new {resource} source from a JSON configuration file.
 

--- a/src/hdx_cli/cli_interface/sources/kafka.py
+++ b/src/hdx_cli/cli_interface/sources/kafka.py
@@ -5,11 +5,7 @@ from hdx_cli.cli_interface.common.misc_operations import settings as command_set
 from hdx_cli.cli_interface.common.rest_operations import delete as command_delete
 from hdx_cli.cli_interface.common.rest_operations import list_ as command_list
 from hdx_cli.cli_interface.common.rest_operations import show as command_show
-from hdx_cli.library_api.utility.decorators import (
-    ensure_logged_in,
-    report_error_and_exit,
-    skip_group_logic_on_help,
-)
+from hdx_cli.library_api.utility.decorators import ensure_logged_in
 from hdx_cli.models import ProfileUserContext
 
 from .common_commands import any_source_impl
@@ -39,8 +35,6 @@ from .common_commands import create as command_create
     default=None,
 )
 @click.pass_context
-@skip_group_logic_on_help
-@report_error_and_exit(exctype=Exception)
 @ensure_logged_in
 def kafka(ctx: click.Context, project_name: str, table_name: str, source_name: str):
     """Manage Kafka sources."""

--- a/src/hdx_cli/cli_interface/sources/kinesis.py
+++ b/src/hdx_cli/cli_interface/sources/kinesis.py
@@ -5,11 +5,7 @@ from hdx_cli.cli_interface.common.misc_operations import settings as command_set
 from hdx_cli.cli_interface.common.rest_operations import delete as command_delete
 from hdx_cli.cli_interface.common.rest_operations import list_ as command_list
 from hdx_cli.cli_interface.common.rest_operations import show as command_show
-from hdx_cli.library_api.utility.decorators import (
-    ensure_logged_in,
-    report_error_and_exit,
-    skip_group_logic_on_help,
-)
+from hdx_cli.library_api.utility.decorators import ensure_logged_in
 from hdx_cli.models import ProfileUserContext
 
 from .common_commands import any_source_impl
@@ -39,8 +35,6 @@ from .common_commands import create as command_create
     default=None,
 )
 @click.pass_context
-@skip_group_logic_on_help
-@report_error_and_exit(exctype=Exception)
 @ensure_logged_in
 def kinesis(ctx: click.Context, project_name: str, table_name: str, source_name: str):
     """Manage Kinesis sources."""

--- a/src/hdx_cli/cli_interface/sources/siem.py
+++ b/src/hdx_cli/cli_interface/sources/siem.py
@@ -5,11 +5,7 @@ from hdx_cli.cli_interface.common.misc_operations import settings as command_set
 from hdx_cli.cli_interface.common.rest_operations import delete as command_delete
 from hdx_cli.cli_interface.common.rest_operations import list_ as command_list
 from hdx_cli.cli_interface.common.rest_operations import show as command_show
-from hdx_cli.library_api.utility.decorators import (
-    ensure_logged_in,
-    report_error_and_exit,
-    skip_group_logic_on_help,
-)
+from hdx_cli.library_api.utility.decorators import ensure_logged_in
 from hdx_cli.models import ProfileUserContext
 
 from .common_commands import any_source_impl
@@ -39,8 +35,6 @@ from .common_commands import create as command_create
     default=None,
 )
 @click.pass_context
-@skip_group_logic_on_help
-@report_error_and_exit(exctype=Exception)
 @ensure_logged_in
 def siem(ctx: click.Context, project_name: str, table_name: str, source_name: str):
     """Manage SIEM sources."""

--- a/src/hdx_cli/cli_interface/storage/commands.py
+++ b/src/hdx_cli/cli_interface/storage/commands.py
@@ -1,22 +1,21 @@
 import click
 
-from hdx_cli.cli_interface.common.click_extensions import HdxGroup, HdxCommand
+from hdx_cli.cli_interface.common.click_extensions import HdxCommand, HdxGroup
 from hdx_cli.cli_interface.common.misc_operations import settings as command_settings
+from hdx_cli.cli_interface.common.rest_operations import delete as command_delete
 from hdx_cli.cli_interface.common.rest_operations import list_ as command_list
 from hdx_cli.cli_interface.common.rest_operations import show as command_show
-from hdx_cli.cli_interface.common.rest_operations import delete as command_delete
 from hdx_cli.cli_interface.common.undecorated_click_commands import basic_create
 from hdx_cli.library_api.common.exceptions import ResourceNotFoundException
 from hdx_cli.library_api.common.generic_resource import access_resource
 from hdx_cli.library_api.common.logging import get_logger
-from hdx_cli.library_api.utility.decorators import report_error_and_exit, ensure_logged_in
+from hdx_cli.library_api.utility.decorators import ensure_logged_in
 from hdx_cli.library_api.utility.file_handling import read_json_from_file
 from hdx_cli.models import ProfileUserContext
 
 logger = get_logger()
 
 
-@report_error_and_exit(exctype=Exception)
 def get_credential_id(ctx, param, value):
     if value is None:
         return value
@@ -38,7 +37,6 @@ def get_credential_id(ctx, param, value):
     help="Perform operation on the passed storage.",
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 @ensure_logged_in
 def storage(ctx: click.Context, storage_name: str):
     """This group of commands allows to create, list,
@@ -104,7 +102,6 @@ def storage(ctx: click.Context, storage_name: str):
     help="I/O performance mode for the storage bucket.",
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def create(
     ctx: click.Context,
     resource_name: str,

--- a/src/hdx_cli/cli_interface/stream/commands.py
+++ b/src/hdx_cli/cli_interface/stream/commands.py
@@ -1,11 +1,11 @@
 import click
 
 from hdx_cli.cli_interface.common.cached_operations import find_transforms
-from hdx_cli.cli_interface.common.click_extensions import HdxGroup, HdxCommand
+from hdx_cli.cli_interface.common.click_extensions import HdxCommand, HdxGroup
 from hdx_cli.cli_interface.common.undecorated_click_commands import basic_create
-from hdx_cli.library_api.common.exceptions import ResourceNotFoundException, LogicException
+from hdx_cli.library_api.common.exceptions import LogicException, ResourceNotFoundException
 from hdx_cli.library_api.common.logging import get_logger
-from hdx_cli.library_api.utility.decorators import ensure_logged_in, report_error_and_exit
+from hdx_cli.library_api.utility.decorators import ensure_logged_in
 from hdx_cli.library_api.utility.file_handling import read_bytes_from_file
 from hdx_cli.models import ProfileUserContext
 
@@ -55,12 +55,9 @@ def stream(ctx: click.Context, project_name: str, table_name: str, transform_nam
 
 @click.command(cls=HdxCommand)
 @click.argument(
-    "data_file_path",
-    metavar="DATA_FILE_PATH",
-    type=click.Path(exists=True, readable=True)
+    "data_file_path", metavar="DATA_FILE_PATH", type=click.Path(exists=True, readable=True)
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def ingest(ctx: click.Context, data_file_path: str):
     """Ingest data from a file into a table.
 
@@ -80,8 +77,9 @@ def ingest(ctx: click.Context, data_file_path: str):
     resource_path = ctx.parent.obj["resource_path"]
     user_profile = ctx.parent.obj["usercontext"]
     if not user_profile.projectname or not user_profile.tablename:
-        raise LogicException("A project and table must be specified "
-                             "via options or set in the current profile.")
+        raise LogicException(
+            "A project and table must be specified " "via options or set in the current profile."
+        )
 
     stream_data_bytes = read_bytes_from_file(data_file_path)
 
@@ -91,14 +89,19 @@ def ingest(ctx: click.Context, data_file_path: str):
 
     transform_to_use = None
     if explicit_transform_name:
-        transform_to_use = next((t for t in transforms_list if t["name"] == explicit_transform_name), None)
+        transform_to_use = next(
+            (t for t in transforms_list if t["name"] == explicit_transform_name), None
+        )
         if not transform_to_use:
             raise ResourceNotFoundException(f"Transform '{explicit_transform_name}' not found.")
     else:
-        transform_to_use = next((t for t in transforms_list if t.get("settings", {}).get("is_default")), None)
+        transform_to_use = next(
+            (t for t in transforms_list if t.get("settings", {}).get("is_default")), None
+        )
         if not transform_to_use:
             raise ResourceNotFoundException(
-                "No default transform found for the table. Please specify one with --transform.")
+                "No default transform found for the table. Please specify one with --transform."
+            )
 
     transform_name = transform_to_use["name"]
     transform_type = transform_to_use["type"]

--- a/src/hdx_cli/cli_interface/svc_account/commands.py
+++ b/src/hdx_cli/cli_interface/svc_account/commands.py
@@ -1,26 +1,28 @@
 import json
-from typing import Dict, Any, Tuple
+from typing import Any, Dict, Tuple
 
 import click
 from rich.console import Console
 from rich.table import Table
 
-from .utils import (
-    create_service_account_token,
-    create_service_account,
-    validate_roles_exist,
-    update_roles,
-    revoke_all_service_account_tokens,
-    set_token_as_auth,
-)
-from hdx_cli.cli_interface.common.click_extensions import HdxGroup, HdxCommand
+from hdx_cli.cli_interface.common.cached_operations import find_service_accounts, find_users
+from hdx_cli.cli_interface.common.click_extensions import HdxCommand, HdxGroup
 from hdx_cli.cli_interface.common.rest_operations import delete as command_delete
 from hdx_cli.cli_interface.common.rest_operations import show as command_show
-from hdx_cli.cli_interface.common.cached_operations import find_service_accounts, find_users
 from hdx_cli.cli_interface.common.undecorated_click_commands import basic_show
 from hdx_cli.library_api.common.exceptions import LogicException, ResourceNotFoundException
-from hdx_cli.library_api.utility.decorators import report_error_and_exit, ensure_logged_in
+from hdx_cli.library_api.utility.decorators import ensure_logged_in
 from hdx_cli.models import ProfileUserContext
+
+from .utils import (
+    create_service_account,
+    create_service_account_token,
+    revoke_all_service_account_tokens,
+    set_token_as_auth,
+    update_roles,
+    validate_duration_format,
+    validate_roles_exist,
+)
 
 console = Console()
 
@@ -51,7 +53,6 @@ def _print_token_details(token_data: Dict[str, Any]):
     help="Perform an operation on the specified service account.",
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 @ensure_logged_in
 def service_account(ctx: click.Context, service_account_name: str):
     """Service accounts are non-human users designed for
@@ -84,15 +85,15 @@ def service_account(ctx: click.Context, service_account_name: str):
     default=None,
     metavar="[DURATION]",
     help="Generate a token after creation. Optionally, provide a duration (e.g., '30d', '1y').",
+    callback=validate_duration_format,
 )
 @click.option(
     "--set-as-auth",
     is_flag=True,
     help="Set the generated token as the authentication method for the current profile. "
-         "This will overwrite any existing credentials.",
+    "This will overwrite any existing credentials.",
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def create(
     ctx: click.Context,
     resource_name: str,
@@ -127,9 +128,9 @@ def create(
         if not svc_account_id:
             raise LogicException("Could not retrieve UUID after service account creation.")
 
-        token_data = create_service_account_token(user_profile,
-                                                  svc_account_id,
-                                                  duration=generate_token_duration)
+        token_data = create_service_account_token(
+            user_profile, svc_account_id, duration=generate_token_duration
+        )
         click.echo("\nToken successfully generated:")
         _print_token_details(token_data)
 
@@ -142,7 +143,6 @@ def create(
 
 @click.command(cls=HdxCommand, name="list")
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def list_service_account(ctx: click.Context):
     """List all available {resource_plural}.
     Displays a table with the names of all {resource_plural} and the roles
@@ -180,6 +180,7 @@ def list_service_account(ctx: click.Context):
     "--duration",
     metavar="DURATION",
     help="Set token lifetime (e.g., '30d', '12h', '1y'). If not set, the API default is used.",
+    callback=validate_duration_format,
 )
 @click.option(
     "--json",
@@ -191,10 +192,9 @@ def list_service_account(ctx: click.Context):
     "--set-as-auth",
     is_flag=True,
     help="Set the generated token as the authentication method for the current profile. "
-         "This will overwrite any existing credentials.",
+    "This will overwrite any existing credentials.",
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def generate_token(
     ctx: click.Context,
     resource_name: str,
@@ -245,7 +245,6 @@ def generate_token(
     help="Bypass the confirmation prompt.",
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def revoke_tokens(ctx: click.Context, resource_name: str, yes: bool):
     """Revoke all active tokens for a {resource}.
 
@@ -289,7 +288,6 @@ def revoke_tokens(ctx: click.Context, resource_name: str, yes: bool):
     help="Role(s) to assign. Can be used multiple times.",
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def assign_role(ctx: click.Context, resource_name: str, roles: Tuple[str]):
     """Assign one or more roles to a {resource}.
 
@@ -323,7 +321,6 @@ def assign_role(ctx: click.Context, resource_name: str, roles: Tuple[str]):
     help="Role(s) to remove. Can be used multiple times.",
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def remove_role(ctx: click.Context, resource_name: str, roles_to_remove: Tuple[str]):
     """Remove one or more roles from a {resource}.
 

--- a/src/hdx_cli/cli_interface/svc_account/utils.py
+++ b/src/hdx_cli/cli_interface/svc_account/utils.py
@@ -1,15 +1,37 @@
 import json
 import re
 from datetime import datetime, timedelta, timezone
-from typing import Dict, Optional, Any
+from typing import Any, Dict, Optional
 
+import click
 import jwt
 
 from hdx_cli.auth.session import save_session_data
 from hdx_cli.cli_interface.common.cached_operations import find_roles
 from hdx_cli.cli_interface.common.undecorated_click_commands import basic_create, basic_delete
 from hdx_cli.library_api.common.exceptions import LogicException, ResourceNotFoundException
-from hdx_cli.models import ProfileUserContext, AuthInfo
+from hdx_cli.models import AuthInfo, ProfileUserContext
+
+
+def validate_duration_format(ctx, param, value):
+    """
+    Validate duration string format (e.g., '30d', '1y').
+    Allows None (option not passed) and empty string (flag without value).
+    """
+    if value is None:
+        return None
+    elif value == "":
+        return ""
+
+    # Validate format
+    match = re.match(r"^(\d+)([dhmy])$", value.lower())
+    if not match:
+        raise click.BadParameter(
+            f"'{value}'. Use a number followed by "
+            "'d' (days), 'h' (hours), 'm' (minutes), or 'y' (years)."
+        )
+
+    return value
 
 
 def _parse_duration_to_iso(duration: str) -> Optional[str]:
@@ -18,12 +40,8 @@ def _parse_duration_to_iso(duration: str) -> Optional[str]:
         return None
 
     match = re.match(r"(\d+)([dhmy])", duration.lower())
-    if not match:
-        raise ValueError(
-            f"Invalid duration format: '{duration}'. Use 'd' (days), 'h' (hours), "
-            f"'m' (minutes), or 'y' (years)."
-        )
 
+    # Assume a match because the callback validated it
     value, unit = int(match.group(1)), match.group(2)
     now = datetime.now(timezone.utc)
 
@@ -33,11 +51,8 @@ def _parse_duration_to_iso(duration: str) -> Optional[str]:
         delta = timedelta(hours=value)
     elif unit == "m":
         delta = timedelta(minutes=value)
-    elif unit == "y":
+    else:  # unit == "y"
         delta = timedelta(days=value * 365)
-    else:
-        # This path should not be reachable due to the regex
-        raise ValueError("Invalid duration unit.")
 
     future_date = now + delta
     # Format to ISO 8601

--- a/src/hdx_cli/cli_interface/table/commands.py
+++ b/src/hdx_cli/cli_interface/table/commands.py
@@ -17,8 +17,6 @@ from hdx_cli.library_api.common.logging import get_logger
 from hdx_cli.library_api.utility.decorators import (
     ensure_logged_in,
     no_rollback_option,
-    report_error_and_exit,
-    skip_group_logic_on_help,
     target_cluster_options,
 )
 from hdx_cli.library_api.utility.file_handling import read_json_from_file, read_plain_file
@@ -43,8 +41,6 @@ logger = get_logger()
     default=None,
 )
 @click.pass_context
-@skip_group_logic_on_help
-@report_error_and_exit(exctype=Exception)
 @ensure_logged_in
 def table(ctx: click.Context, project_name: str, table_name: str):
     """This group of commands allows to create, list, show, delete, truncate,
@@ -100,7 +96,6 @@ def table(ctx: click.Context, project_name: str, table_name: str):
     help="Path to a JSON file with additional table settings.",
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def create(
     ctx: click.Context,
     resource_name: str,
@@ -176,7 +171,6 @@ def _truncate_table(profile: ProfileUserContext, resource_path: str, resource_na
     help="Bypass the confirmation prompt.",
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def truncate(ctx: click.Context, resource_name: str, yes: bool):
     """Remove all data from a {resource}.
 
@@ -214,7 +208,6 @@ def truncate(ctx: click.Context, resource_name: str, yes: bool):
     help="Migrate only the table, skipping its associated transforms.",
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def migrate(
     ctx: click.Context,
     target_project_name: str,

--- a/src/hdx_cli/cli_interface/transform/commands.py
+++ b/src/hdx_cli/cli_interface/transform/commands.py
@@ -11,8 +11,6 @@ from hdx_cli.library_api.common.logging import get_logger
 from hdx_cli.library_api.utility.decorators import (
     ensure_logged_in,
     no_rollback_option,
-    report_error_and_exit,
-    skip_group_logic_on_help,
     target_cluster_options,
 )
 from hdx_cli.library_api.utility.file_handling import read_json_from_file
@@ -47,8 +45,6 @@ logger = get_logger()
     default=None,
 )
 @click.pass_context
-@skip_group_logic_on_help
-@report_error_and_exit(exctype=Exception)
 @ensure_logged_in
 def transform(ctx: click.Context, project_name: str, table_name: str, transform_name: str):
     """This group of commands allows to create, list, show, delete, and
@@ -84,7 +80,6 @@ def transform(ctx: click.Context, project_name: str, table_name: str, transform_
     hidden=True,
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def create(ctx: click.Context, resource_name: str, settings_filename: str, force: bool):
     """Creates a new {resource} from a JSON configuration file
     in the specified project and table.
@@ -115,7 +110,6 @@ def create(ctx: click.Context, resource_name: str, settings_filename: str, force
 @target_cluster_options
 @no_rollback_option
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def migrate(
     ctx: click.Context,
     target_project_name: str,

--- a/src/hdx_cli/cli_interface/transform/compare.py
+++ b/src/hdx_cli/cli_interface/transform/compare.py
@@ -9,18 +9,14 @@ from hdx_cli.cli_interface.common.undecorated_click_commands import basic_transf
 from hdx_cli.cli_interface.transform.comparator.engine import TransformComparator
 from hdx_cli.config.paths import PROFILE_CONFIG_FILE
 from hdx_cli.library_api.common.logging import get_logger
-from hdx_cli.library_api.utility.decorators import report_error_and_exit
 from hdx_cli.library_api.utility.file_handling import read_json_from_file
-from hdx_cli.models import ProfileUserContext, ProfileLoadContext
+from hdx_cli.models import ProfileLoadContext, ProfileUserContext
 
 logger = get_logger()
 
 
 def _fetch_transform_from_cluster(
-    ctx: click.Context,
-    project_name: str,
-    table_name: str,
-    transform_name: str
+    ctx: click.Context, project_name: str, table_name: str, transform_name: str
 ) -> dict:
     """Fetches a single transform's configuration from
     the cluster. Returns the configuration as a dictionary."""
@@ -39,16 +35,18 @@ def _load_transform_spec(
     """Loads a transform from a local file path or a cluster reference.
     A cluster reference is in the format 'project.table.transform'.
     Returns a tuple of (transform_data, description)."""
-    if Path(specifier).is_file() and specifier.endswith('.json'):
+    if Path(specifier).is_file() and specifier.endswith(".json"):
         logger.debug(f"Loading transform from local file: {specifier}")
         return read_json_from_file(specifier), f"local file: {specifier}"
 
     # Check for cluster reference format: project.table.transform
-    parts = specifier.split('.')
+    parts = specifier.split(".")
     if len(parts) == 3:
         project, table, transform = parts
         user_profile = ctx.parent.obj["usercontext"]
-        logger.debug(f"Fetching transform '{transform}' from cluster '{user_profile.profilename}'...")
+        logger.debug(
+            f"Fetching transform '{transform}' from cluster '{user_profile.profilename}'..."
+        )
         data = _fetch_transform_from_cluster(ctx, project, table, transform)
         return data, f"cluster '{user_profile.profilename}': {specifier}"
 
@@ -67,13 +65,7 @@ def _load_transform_spec(
     metavar="PROFILE_NAME",
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
-def compare(
-    ctx_a: click.Context,
-    transform_a_spec: str,
-    transform_b_spec: str,
-    profile_b: str
-):
+def compare(ctx_a: click.Context, transform_a_spec: str, transform_b_spec: str, profile_b: str):
     """Compares two transforms, showing differences in their settings.
 
     Transforms can be specified as a local JSON file path or as a reference

--- a/src/hdx_cli/cli_interface/user/commands.py
+++ b/src/hdx_cli/cli_interface/user/commands.py
@@ -6,16 +6,16 @@ import click
 from rich.console import Console
 from rich.table import Table
 
-from hdx_cli.cli_interface.common.cached_operations import find_users, find_invites_user
-from hdx_cli.cli_interface.common.click_extensions import HdxGroup, HdxCommand
+from hdx_cli.cli_interface.common.cached_operations import find_invites_user, find_users
+from hdx_cli.cli_interface.common.click_extensions import HdxCommand, HdxGroup
 from hdx_cli.cli_interface.common.undecorated_click_commands import (
-    basic_show,
+    basic_create,
     basic_delete,
-    basic_create
+    basic_show,
 )
 from hdx_cli.library_api.common.exceptions import LogicException
 from hdx_cli.library_api.common.logging import get_logger
-from hdx_cli.library_api.utility.decorators import ensure_logged_in, report_error_and_exit, dynamic_confirmation_prompt
+from hdx_cli.library_api.utility.decorators import dynamic_confirmation_prompt, ensure_logged_in
 from hdx_cli.models import ProfileUserContext
 
 logger = get_logger()
@@ -42,7 +42,6 @@ def user(ctx: click.Context, user_email: str):
 
 @click.command(cls=HdxCommand, name="list")
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def list_users(ctx: click.Context):
     """List all {resource_plural}.
 
@@ -84,7 +83,6 @@ def list_users(ctx: click.Context):
     help="Output in indented JSON format.",
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def show(ctx: click.Context, resource_email: str, indent: bool):
     """Show details for a specific {resource}.
 
@@ -130,7 +128,6 @@ _confirmation_prompt = partial(
 )
 @click.argument("resource_name", metavar="USER_EMAIL")
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def delete(ctx: click.Context, resource_name: str, disable_confirmation_prompt: bool):
     """Permanently deletes the specified {resource}. This action
     is irreversible.
@@ -161,7 +158,6 @@ def delete(ctx: click.Context, resource_name: str, disable_confirmation_prompt: 
     help="Role to assign. Can be used multiple times.",
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def assign(ctx: click.Context, resource_email: str, roles: list):
     """Assign one or more roles to a {resource}.
     This command adds roles to an existing {resource}.
@@ -173,9 +169,9 @@ def assign(ctx: click.Context, resource_email: str, roles: list):
     """
     profile = ctx.parent.obj.get("usercontext")
     resource_path = ctx.parent.obj.get("resource_path")
-    user_uuid = json.loads(basic_show(profile, resource_path, resource_email, filter_field="email")).get(
-        "uuid"
-    )
+    user_uuid = json.loads(
+        basic_show(profile, resource_path, resource_email, filter_field="email")
+    ).get("uuid")
 
     resource_path = f"{resource_path}{user_uuid}/add_roles/"
     body = {"roles": roles}
@@ -195,7 +191,6 @@ def assign(ctx: click.Context, resource_email: str, roles: list):
     help="Role to remove. Can be used multiple times.",
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def remove(ctx: click.Context, resource_email: str, roles: list):
     """Remove one or more roles from a {resource}.
     This command removes existing roles from a {resource}.
@@ -258,7 +253,6 @@ def invite(ctx: click.Context, user_email: str):
     help="Role to assign to the new user. Can be used multiple times.",
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def send(ctx: click.Context, resource_email: str, roles: Tuple[str]):
     """Create and send a new {resource}.
     Sends an email invitation to a new user with a specific set of roles.
@@ -280,7 +274,6 @@ def send(ctx: click.Context, resource_email: str, roles: Tuple[str]):
 @click.command(cls=HdxCommand)
 @click.argument("resource_email", metavar="INVITE_EMAIL")
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def resend(ctx: click.Context, resource_email: str):
     """Resend an existing {resource}.
     Resends an invitation to a user, typically when the original invitation
@@ -293,9 +286,9 @@ def resend(ctx: click.Context, resource_email: str):
     """
     resource_path = ctx.parent.obj.get("resource_path")
     profile = ctx.parent.obj.get("usercontext")
-    invite_id = json.loads(basic_show(profile, resource_path, resource_email, filter_field="email")).get(
-        "id"
-    )
+    invite_id = json.loads(
+        basic_show(profile, resource_path, resource_email, filter_field="email")
+    ).get("id")
     resource_path = f"{resource_path}{invite_id}/resend_invite/"
     basic_create(profile, resource_path)
     logger.info(f"Resent invitation to {resource_email}")
@@ -304,7 +297,6 @@ def resend(ctx: click.Context, resource_email: str):
 @click.command(cls=HdxCommand, name="list")
 @click.option("-p", "--pending", is_flag=True, default=False, help="List only pending invitations.")
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def list_invites(ctx: click.Context, pending: bool):
     """List all {resource_plural}.
 

--- a/src/hdx_cli/cli_interface/view/commands.py
+++ b/src/hdx_cli/cli_interface/view/commands.py
@@ -7,11 +7,7 @@ from hdx_cli.cli_interface.common.rest_operations import list_ as command_list
 from hdx_cli.cli_interface.common.rest_operations import show as command_show
 from hdx_cli.cli_interface.common.undecorated_click_commands import basic_create, basic_view
 from hdx_cli.library_api.common.logging import get_logger
-from hdx_cli.library_api.utility.decorators import (
-    ensure_logged_in,
-    report_error_and_exit,
-    skip_group_logic_on_help,
-)
+from hdx_cli.library_api.utility.decorators import ensure_logged_in
 from hdx_cli.library_api.utility.file_handling import read_json_from_file
 from hdx_cli.models import ProfileUserContext
 
@@ -42,8 +38,6 @@ logger = get_logger()
     default=None,
 )
 @click.pass_context
-@skip_group_logic_on_help
-@report_error_and_exit(exctype=Exception)
 @ensure_logged_in
 def view(ctx: click.Context, project_name: str, table_name: str, view_name: str):
     """This group of commands allows to create, list, show, delete, and
@@ -67,7 +61,6 @@ def view(ctx: click.Context, project_name: str, table_name: str, view_name: str)
     required=True,
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def create(ctx: click.Context, resource_name: str, settings_filename: str):
     """Creates a new {resource} from a JSON configuration file
     in the specified project and table.

--- a/src/hdx_cli/library_api/utility/decorators.py
+++ b/src/hdx_cli/library_api/utility/decorators.py
@@ -1,7 +1,6 @@
 import atexit
 import functools
 import pickle
-import sys
 from functools import wraps
 from pathlib import Path
 
@@ -10,33 +9,10 @@ import toml
 
 from ...auth.context_builder import load_user_context
 from ...config.paths import PROFILE_CONFIG_FILE
-from ...models import ProfileLoadContext
-from ..common.exceptions import HdxCliException, HttpException
+from ..common.exceptions import HdxCliException
 from ..common.logging import get_logger
-from .json_util import http_error_pretty_format
 
 logger = get_logger()
-
-
-def report_error_and_exit(exctype=Exception, exit_code=-1):
-    def report_deco(func):
-        @wraps(func)
-        def report_wrapper(*args, **kwargs):
-            try:
-                return func(*args, **kwargs)
-            except click.Abort:
-                raise
-            except exctype as exc:
-                logger.debug(f"{exc}")
-                if isinstance(exc, HttpException):
-                    logger.error(f"Error: {http_error_pretty_format(exc)}")
-                else:
-                    logger.error(f"Error: {exc}")
-                sys.exit(exit_code)
-
-        return report_wrapper
-
-    return report_deco
 
 
 def dynamic_confirmation_prompt(prompt, confirmation_message, fail_message, *, prompt_active=False):
@@ -145,18 +121,6 @@ def with_profiles_context(func):
         return func(ctx, profile_context, profile_configs, *args, **kwargs)
 
     return decorated_function
-
-
-def skip_group_logic_on_help(func):
-    """Decorator to skip group logic if --help is in sys.argv."""
-
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-        if "--help" in sys.argv:
-            return
-        return func(*args, **kwargs)
-
-    return wrapper
 
 
 def no_rollback_option(func):

--- a/src/hdx_cli/main.py
+++ b/src/hdx_cli/main.py
@@ -1,16 +1,17 @@
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
 import click
-from importlib.metadata import version, PackageNotFoundError
 from trogon import tui
 
 from hdx_cli.auth.context_builder import load_user_context
 from hdx_cli.cli_interface.check_health import commands as check_health_
 from hdx_cli.cli_interface.column import commands as column_
-from hdx_cli.cli_interface.common.click_extensions import HdxGroup, HdxCommand
+from hdx_cli.cli_interface.common.click_extensions import HdxCliGroup, HdxCommand
 from hdx_cli.cli_interface.credential import commands as credentials_
 from hdx_cli.cli_interface.defaults import commands as defaults_
 from hdx_cli.cli_interface.dictionary import commands as dictionary_
+from hdx_cli.cli_interface.docs import commands as docs_
 from hdx_cli.cli_interface.function import commands as function_
 from hdx_cli.cli_interface.integration import commands as integration_
 from hdx_cli.cli_interface.job import commands as job_
@@ -32,12 +33,10 @@ from hdx_cli.cli_interface.table import commands as table_
 from hdx_cli.cli_interface.transform import commands as transform_
 from hdx_cli.cli_interface.user import commands as user_
 from hdx_cli.cli_interface.view import commands as view_
-from hdx_cli.cli_interface.docs import commands as docs_
 from hdx_cli.config.initial_setup import first_time_use_config, is_first_time_use
 from hdx_cli.library_api.common.config_constants import PROFILE_CONFIG_FILE
 from hdx_cli.library_api.common.exceptions import ConfigurationExistsException
 from hdx_cli.library_api.common.logging import get_logger, set_debug_logger, set_info_logger
-from hdx_cli.library_api.utility.decorators import report_error_and_exit
 from hdx_cli.models import DEFAULT_TIMEOUT, ProfileLoadContext
 
 try:
@@ -57,8 +56,9 @@ def configure_logger(debug=False):
 
 # pylint: disable=line-too-long
 
+
 @tui(help="Open a Textual User Interface (TUI) for the CLI.")
-@click.group(cls=HdxGroup)
+@click.group(cls=HdxCliGroup)
 @click.option(
     "--profile",
     metavar="PROFILENAME",
@@ -112,7 +112,6 @@ def configure_logger(debug=False):
     "debug messages for troubleshooting purposes.",
 )
 @click.pass_context
-@report_error_and_exit(exctype=Exception)
 def hdx_cli(
     ctx,
     profile: str,
@@ -149,7 +148,7 @@ def hdx_cli(
     else:
         profile_context = ProfileLoadContext(profile, profile_config_file)
 
-    ctx.obj = {"profilecontext": profile_context}
+    ctx.obj = {"profilecontext": profile_context, "DEBUG": debug}
     user_options = {
         "username": username,
         "password": password,
@@ -162,7 +161,6 @@ def hdx_cli(
 
 
 @click.command(cls=HdxCommand, name="init")
-@report_error_and_exit(exctype=Exception)
 def init():
     """
     Initialize the HDXCLI configuration for first-time use.

--- a/tests/command_line_interface/test_cases/test_read_only_flows.toml
+++ b/tests/command_line_interface/test_cases/test_read_only_flows.toml
@@ -985,7 +985,7 @@ expected_output = "Removed role(s) from 'test_ci_service_account'"
 [[test]]
 name = "Generating a token with an invalid duration format fails gracefully"
 commands_under_test = ["python3 -m hdx_cli.main service-account generate-token test_ci_service_account --duration 30x"]
-expected_output = "Error: Invalid duration format: '30x'. Use 'd' (days), 'h' (hours), 'm' (minutes), or 'y' (years)."
+expected_output_expr = "'Invalid value for' in result and '--duration' in result"
 
 
 ################################################### query-options ####################################################

--- a/tests/command_line_interface/test_runner_approval.py
+++ b/tests/command_line_interface/test_runner_approval.py
@@ -144,11 +144,13 @@ class ApprovalTestCaseRunner:
         try:
             for command in self._setup_steps:
                 command_capture = " ".join(command)
-                result_obj = sp.run(command, capture_output=True, check=True)
+                sp.run(command, capture_output=True, check=True)
             for command in input_commands:
                 command_capture = " ".join(command)
                 result_obj = sp.run(command, capture_output=True, check=False)
-                result = result_obj.stdout.rstrip().decode("utf-8")
+                stdout_res = result_obj.stdout.decode("utf-8").rstrip()
+                stderr_res = result_obj.stderr.decode("utf-8").rstrip()
+                result = stdout_res + stderr_res
         except HdxCliException:
             pytest.fail(
                 f"An exception occurred when trying to run '{self._name}'. Command: "


### PR DESCRIPTION
This PR refactors the CLI's error and exception handling mechanism to improve the developer experience and centralize logic.

Previously, error handling was managed by a repetitive `@report_error_and_exit` decorator applied to all commands. This approach made debugging difficult, as it caught exceptions prematurely and hid the full traceback from the developer.

This change introduces a centralized handler in a custom `HdxCliGroup` class. This class now intercepts all runtime exceptions, providing consistent user-facing error messages while allowing the global `--debug` flag to reveal the full stack trace for unexpected errors.