### PR TITLE
[HDX-8531] Add new 'update' command

### DIFF
--- a/src/hdx_cli/cli_interface/dictionary/commands.py
+++ b/src/hdx_cli/cli_interface/dictionary/commands.py
@@ -6,11 +6,7 @@ from hdx_cli.cli_interface.common.misc_operations import settings as command_set
 from hdx_cli.cli_interface.common.rest_operations import delete as command_delete
 from hdx_cli.cli_interface.common.rest_operations import list_ as command_list
 from hdx_cli.cli_interface.common.rest_operations import show as command_show
-from hdx_cli.cli_interface.common.undecorated_click_commands import (
-    basic_create,
-    basic_create_file,
-    basic_delete,
-)
+from hdx_cli.cli_interface.common.undecorated_click_commands import basic_create
 from hdx_cli.library_api.common.exceptions import (
     MissingSettingsException,
     ResourceNotFoundException,
@@ -24,15 +20,15 @@ from hdx_cli.library_api.utility.decorators import (
     skip_group_logic_on_help,
     target_cluster_options,
 )
-from hdx_cli.library_api.utility.file_handling import read_bytes_from_file, read_json_from_file
+from hdx_cli.library_api.utility.file_handling import read_json_from_file
 from hdx_cli.models import ProfileUserContext
 
-from .operations import download_dictionary_file
+from .files import files_group as files
 
 logger = get_logger()
 
 
-@click.group(cls=HdxGroup)
+@click.group(cls=HdxGroup, name="dictionary")
 @click.option(
     "--project",
     "project_name",
@@ -74,7 +70,7 @@ def dictionary(ctx: click.Context, project_name: str, dictionary_name: str):
     ctx.obj = {"resource_path": resource_path, "usercontext": user_profile}
 
 
-@click.command(cls=HdxCommand)
+@click.command(cls=HdxCommand, name="create")
 @click.argument(
     "dict_settings_file_path",
     metavar="DICT_SETTINGS_FILE_PATH",
@@ -118,7 +114,7 @@ def create(
     logger.info(f"Created {ctx.parent.command.name} {resource_name}")
 
 
-@click.command(cls=HdxCommand)
+@click.command(cls=HdxCommand, name="migrate")
 @click.argument("target_project_name", metavar="TARGET_PROJECT_NAME")
 @click.argument("new_dictionary_name", metavar="NEW_DICTIONARY_NAME")
 @target_cluster_options
@@ -192,125 +188,10 @@ def migrate(
     logger.info("All resources migrated successfully")
 
 
-@click.command(cls=HdxCommand, name="download")
-@click.argument("dictionary_filename", metavar="DICTIONARY_FILENAME")
-@click.option(
-    "--output",
-    "-o",
-    "output_path",
-    help="Path to save the file, including the new filename. "
-    "If not provided, saves to the current directory with the original name.",
-    type=click.Path(dir_okay=False, writable=True),
-    default=None,
-)
-@click.pass_context
-@report_error_and_exit(exctype=Exception)
-def download_file(ctx: click.Context, dictionary_filename: str, output_path: str):
-    """
-    Download a dictionary data file to your local machine.
-    This command retrieves a dictionary file and saves it
-    to a specified path, or the current directory by default.
-
-    \b
-    Examples:
-      # Download 'countries' to the current directory
-      hdxcli dictionary --project my_proj files download countries
-
-    \b
-      # Download 'countries' but save it as 'country_list.csv' in the current dir
-      hdxcli dictionary --project my_proj files download countries.csv -o country_list.csv
-
-    \b
-      # Download 'countries' to a specific 'data' folder with 'countries.csv' as the new filename
-      hdxcli dictionary --project my_proj files download countries.csv -o ./data/countries.csv
-    """
-    profile = ctx.parent.obj["usercontext"]
-    # The resource path is for 'files', which is what the operation function expects
-    resource_path = ctx.parent.obj["resource_path"]
-    download_dictionary_file(profile, resource_path, dictionary_filename, output_path)
-
-
-@click.group(cls=HdxGroup)
-@click.pass_context
-@skip_group_logic_on_help
-@report_error_and_exit(exctype=Exception)
-def files(ctx: click.Context):
-    """Manage dictionary data files."""
-    user_profile = ctx.parent.obj["usercontext"]
-    resource_path = f'{ctx.obj["resource_path"]}files'
-    ctx.obj = {"resource_path": resource_path, "usercontext": user_profile}
-
-
-@click.command(cls=HdxCommand)
-@click.argument(
-    "file_path_to_upload",
-    metavar="FILE_PATH_TO_UPLOAD",
-    type=click.Path(exists=True, readable=True),
-)
-@click.argument("dict_file_name", metavar="DICT_FILE_NAME")
-@click.option(
-    "--body-from-file-type",
-    "-t",
-    type=click.Choice(("json", "verbatim"), case_sensitive=False),
-    help="How to interpret the body from the file. Defaults to 'json'.",
-    default="json",
-)
-@click.pass_context
-@report_error_and_exit(exctype=Exception)
-def files_upload(
-    ctx: click.Context,
-    file_path_to_upload: str,
-    dict_file_name: str,
-    body_from_file_type: str,
-):
-    """Upload a dictionary data file.
-
-    \b
-    Examples:
-      # Upload a local CSV file to be used as a data source for a dictionary
-      hdxcli dictionary --project my_project files upload ./local_countries.csv countries -t verbatim
-    """
-    profile = ctx.parent.obj["usercontext"]
-    resource_path = ctx.parent.obj["resource_path"]
-    file_content = read_bytes_from_file(file_path_to_upload)
-    basic_create_file(
-        profile,
-        resource_path,
-        dict_file_name,
-        file_content=file_content,
-        file_type=body_from_file_type,
-    )
-    logger.info(f"Uploaded dictionary file {dict_file_name}")
-
-
-@click.command(cls=HdxCommand)
-@click.argument("file_name", metavar="FILE_NAME")
-@click.pass_context
-@report_error_and_exit(exctype=Exception)
-def files_delete(ctx: click.Context, file_name: str):
-    """Delete a dictionary data file.
-
-    \b
-    Examples:
-      # Delete the file named 'my_dictionary_file'
-      hdxcli dictionary --project my_project files delete my_dictionary_file
-    """
-    profile = ctx.parent.obj["usercontext"]
-    resource_path = ctx.parent.obj["resource_path"]
-    hostname = profile.hostname
-    scheme = profile.scheme
-    resource_url = f"{scheme}://{hostname}{resource_path}/{file_name}"
-    basic_delete(profile, resource_path, file_name, url=resource_url)
-    logger.info(f"Deleted dictionary file {file_name}")
-
-
-dictionary.add_command(create, name="create")
+# Subgroup
 dictionary.add_command(files)
-files.add_command(files_upload, name="upload")
-files.add_command(command_list)
-files.add_command(download_file)
-files.add_command(files_delete, name="delete")
-
+# Commands
+dictionary.add_command(create)
 dictionary.add_command(command_list)
 dictionary.add_command(command_delete)
 dictionary.add_command(command_show)

--- a/src/hdx_cli/cli_interface/dictionary/files.py
+++ b/src/hdx_cli/cli_interface/dictionary/files.py
@@ -1,18 +1,45 @@
 import click
+from InquirerPy import prompt
+from InquirerPy.validator import EmptyInputValidator
 
 from hdx_cli.cli_interface.common.click_extensions import HdxCommand, HdxGroup
 from hdx_cli.cli_interface.common.rest_operations import list_ as command_list
 from hdx_cli.cli_interface.common.undecorated_click_commands import (
     basic_create_file,
     basic_delete,
+    generic_basic_list,
 )
 from hdx_cli.library_api.common.logging import get_logger
 from hdx_cli.library_api.utility.decorators import report_error_and_exit, skip_group_logic_on_help
 from hdx_cli.library_api.utility.file_handling import read_bytes_from_file
 
+from ...models import ProfileUserContext
 from .operations import download_dictionary_file
 
 logger = get_logger()
+
+
+def _delete_file_logic(profile: ProfileUserContext, resource_path: str, file_name: str):
+    """Core logic to delete a dictionary file."""
+    hostname = profile.hostname
+    scheme = profile.scheme
+    resource_url = f"{scheme}://{hostname}{resource_path}/{file_name}"
+    basic_delete(profile, resource_path, file_name, url=resource_url)
+    logger.info(f"Deleted dictionary file {file_name}")
+
+
+def _upload_file_logic(
+    profile: ProfileUserContext, resource_path: str, local_path: str, remote_name: str
+):
+    """Core logic to upload a dictionary file."""
+    file_content = read_bytes_from_file(local_path)
+    basic_create_file(
+        profile,
+        resource_path,
+        remote_name,
+        file_content=file_content,
+    )
+    logger.info(f"Uploaded dictionary file {remote_name}")
 
 
 @click.group(cls=HdxGroup, name="files")
@@ -58,15 +85,7 @@ def upload(
     """
     profile = ctx.parent.obj["usercontext"]
     resource_path = ctx.parent.obj["resource_path"]
-    file_content = read_bytes_from_file(file_path_to_upload)
-    basic_create_file(
-        profile,
-        resource_path,
-        dict_file_name,
-        file_content=file_content,
-        file_type=body_from_file_type,
-    )
-    logger.info(f"Uploaded dictionary file {dict_file_name}")
+    _upload_file_logic(profile, resource_path, file_path_to_upload, dict_file_name)
 
 
 @click.command(cls=HdxCommand, name="download")
@@ -120,14 +139,115 @@ def delete(ctx: click.Context, file_name: str):
     """
     profile = ctx.parent.obj["usercontext"]
     resource_path = ctx.parent.obj["resource_path"]
-    hostname = profile.hostname
-    scheme = profile.scheme
-    resource_url = f"{scheme}://{hostname}{resource_path}/{file_name}"
-    basic_delete(profile, resource_path, file_name, url=resource_url)
-    logger.info(f"Deleted dictionary file {file_name}")
+    _delete_file_logic(profile, resource_path, file_name)
+
+
+@click.command(cls=HdxCommand, name="update")
+@click.argument(
+    "local_file_path",
+    metavar="LOCAL_FILE_PATH",
+    type=click.Path(exists=True, readable=True, resolve_path=True),
+)
+@click.argument("remote_file_name", metavar="REMOTE_FILE_NAME", required=False)
+@click.option(
+    "-y",
+    "--yes",
+    is_flag=True,
+    help="Skip the confirmation prompt and proceed with the update.",
+)
+@click.pass_context
+@report_error_and_exit(exctype=Exception)
+def update(
+    ctx: click.Context,
+    local_file_path: str,
+    remote_file_name: str,
+    yes: bool,
+):
+    """Updates an existing dictionary data file by replacing it.
+
+    This command provides a convenient way to replace a remote dictionary
+    file with a local version in a single step. It first deletes the
+    existing remote file and then uploads the new one.
+
+    \b
+    The command can be run in two modes:
+     - INTERACTIVE: If `REMOTE_FILE_NAME` is not provided, you will be
+       prompted to select from a list of existing files.
+     - DIRECT: If `REMOTE_FILE_NAME` is provided, the command will target
+       that file directly. For safety, a confirmation prompt is still
+       shown unless the `--yes` flag is used.
+
+    \b
+    Examples:
+      # Interactively update a dictionary file in the 'my_project' project
+      hdxcli dictionary --project my_project files update ./new_countries.csv
+
+    \b
+      # Directly update 'countries' file after asking for confirmation
+      hdxcli dictionary --project my_project files update ./new_countries.csv countries
+
+    \b
+      # Directly update 'cities' file without any prompts
+      hdxcli dictionary --project my_project files update ./new_cities.json cities --yes
+    """
+    profile = ctx.parent.obj["usercontext"]
+    resource_path = ctx.parent.obj["resource_path"]
+    file_to_replace = remote_file_name
+
+    remote_files = generic_basic_list(profile, resource_path)
+    if not remote_files:
+        raise click.ClickException(
+            f"No dictionary files found in project '{profile.projectname}' to update."
+        )
+
+    if not file_to_replace:
+        if yes:
+            raise click.UsageError(
+                "Cannot use --yes in interactive mode. Please provide REMOTE_FILE_NAME."
+            )
+
+        questions = [
+            {
+                "type": "list",
+                "message": "Select the dictionary file to replace:",
+                "choices": remote_files,
+                "name": "file_to_replace",
+                "validate": EmptyInputValidator(),
+            }
+        ]
+        result = prompt(questions=questions)
+        if not result:
+            raise click.Abort()
+        file_to_replace = result["file_to_replace"]
+    else:
+        if file_to_replace not in remote_files:
+            raise click.ClickException(
+                f"File '{file_to_replace}' not found in project '{profile.projectname}'."
+            )
+
+    if not yes:
+        confirm_questions = [
+            {
+                "type": "confirm",
+                "message": f"This will permanently replace '{file_to_replace}' in project '{profile.projectname}'."
+                f"\n  Are you sure you want to continue?",
+                "name": "confirm",
+                "default": False,
+            }
+        ]
+        confirm_result = prompt(questions=confirm_questions)
+        if not confirm_result or not confirm_result.get("confirm"):
+            logger.info("Update cancelled by user.")
+            return
+
+    logger.info(f"Replacing '{file_to_replace}'...")
+    _delete_file_logic(profile, resource_path, file_to_replace)
+    _upload_file_logic(profile, resource_path, local_file_path, file_to_replace)
+    logger.info(f"Successfully updated dictionary file '{file_to_replace}'")
 
 
 files_group.add_command(upload)
 files_group.add_command(download)
 files_group.add_command(delete)
+files_group.add_command(update)
 files_group.add_command(command_list)

--- a/src/hdx_cli/cli_interface/dictionary/files.py
+++ b/src/hdx_cli/cli_interface/dictionary/files.py
@@ -1,4 +1,5 @@
 import click
+from click.core import ParameterSource
 from InquirerPy import prompt
 from InquirerPy.validator import EmptyInputValidator
 
@@ -17,6 +18,18 @@ from ...models import ProfileUserContext
 from .operations import download_dictionary_file
 
 logger = get_logger()
+
+
+def _warn_on_deprecated_file_type(ctx, param, value):
+    """Callback to show a deprecation warning for the file_type option."""
+    source = ctx.get_parameter_source(param.name)
+    if source is ParameterSource.COMMANDLINE:
+        warning = (
+            f"Warning: The '--{param.name}' option is deprecated "
+            "and will be removed in a future version. It has no effect."
+        )
+        click.secho(warning, err=True, fg="yellow")
+    return value
 
 
 def _delete_file_logic(profile: ProfileUserContext, resource_path: str, file_name: str):
@@ -65,8 +78,11 @@ def files_group(ctx: click.Context):
     "--body-from-file-type",
     "-t",
     type=click.Choice(("json", "verbatim"), case_sensitive=False),
-    help="How to interpret the body from the file. Defaults to 'json'.",
     default="json",
+    help="[DEPRECATED] This option has no effect and will be removed.",
+    hidden=True,
+    callback=_warn_on_deprecated_file_type,
+    is_eager=True,
 )
 @click.pass_context
 @report_error_and_exit(exctype=Exception)
@@ -81,7 +97,11 @@ def upload(
     \b
     Examples:
       # Upload a local CSV file to be used as a data source for a dictionary
-      hdxcli dictionary --project my_project files upload ./local_countries.csv countries -t verbatim
+      hdxcli dictionary --project my_project files upload ./countries.csv countries
+
+    \b
+      # Upload a local JSON file to be used as a data source for a dictionary
+      hdxcli dictionary --project my_project files upload ./cities.json cities
     """
     profile = ctx.parent.obj["usercontext"]
     resource_path = ctx.parent.obj["resource_path"]

--- a/src/hdx_cli/cli_interface/dictionary/files.py
+++ b/src/hdx_cli/cli_interface/dictionary/files.py
@@ -1,0 +1,133 @@
+import click
+
+from hdx_cli.cli_interface.common.click_extensions import HdxCommand, HdxGroup
+from hdx_cli.cli_interface.common.rest_operations import list_ as command_list
+from hdx_cli.cli_interface.common.undecorated_click_commands import (
+    basic_create_file,
+    basic_delete,
+)
+from hdx_cli.library_api.common.logging import get_logger
+from hdx_cli.library_api.utility.decorators import report_error_and_exit, skip_group_logic_on_help
+from hdx_cli.library_api.utility.file_handling import read_bytes_from_file
+
+from .operations import download_dictionary_file
+
+logger = get_logger()
+
+
+@click.group(cls=HdxGroup, name="files")
+@click.pass_context
+@skip_group_logic_on_help
+@report_error_and_exit(exctype=Exception)
+def files_group(ctx: click.Context):
+    """Manage dictionary data files."""
+    user_profile = ctx.parent.obj["usercontext"]
+    base_path = ctx.obj["resource_path"]
+    resource_path = f"{base_path}files"
+    ctx.obj = {"resource_path": resource_path, "usercontext": user_profile}
+
+
+@click.command(cls=HdxCommand, name="upload")
+@click.argument(
+    "file_path_to_upload",
+    metavar="FILE_PATH_TO_UPLOAD",
+    type=click.Path(exists=True, readable=True),
+)
+@click.argument("dict_file_name", metavar="DICT_FILE_NAME")
+@click.option(
+    "--body-from-file-type",
+    "-t",
+    type=click.Choice(("json", "verbatim"), case_sensitive=False),
+    help="How to interpret the body from the file. Defaults to 'json'.",
+    default="json",
+)
+@click.pass_context
+@report_error_and_exit(exctype=Exception)
+def upload(
+    ctx: click.Context,
+    file_path_to_upload: str,
+    dict_file_name: str,
+    body_from_file_type: str,
+):
+    """Upload a dictionary data file.
+
+    \b
+    Examples:
+      # Upload a local CSV file to be used as a data source for a dictionary
+      hdxcli dictionary --project my_project files upload ./local_countries.csv countries -t verbatim
+    """
+    profile = ctx.parent.obj["usercontext"]
+    resource_path = ctx.parent.obj["resource_path"]
+    file_content = read_bytes_from_file(file_path_to_upload)
+    basic_create_file(
+        profile,
+        resource_path,
+        dict_file_name,
+        file_content=file_content,
+        file_type=body_from_file_type,
+    )
+    logger.info(f"Uploaded dictionary file {dict_file_name}")
+
+
+@click.command(cls=HdxCommand, name="download")
+@click.argument("dictionary_filename", metavar="DICTIONARY_FILENAME")
+@click.option(
+    "--output",
+    "-o",
+    "output_path",
+    help="Path to save the file, including the new filename. "
+    "If not provided, saves to the current directory with the original name.",
+    type=click.Path(dir_okay=False, writable=True),
+    default=None,
+)
+@click.pass_context
+@report_error_and_exit(exctype=Exception)
+def download(ctx: click.Context, dictionary_filename: str, output_path: str):
+    """
+    Download a dictionary data file to your local machine.
+    This command retrieves a dictionary file and saves it
+    to a specified path, or the current directory by default.
+
+    \b
+    Examples:
+      # Download 'countries' to the current directory
+      hdxcli dictionary --project my_proj files download countries
+
+    \b
+      # Download 'countries' but save it as 'country_list.csv' in the current dir
+      hdxcli dictionary --project my_proj files download countries.csv -o country_list.csv
+
+    \b
+      # Download 'countries' to a specific 'data' folder with 'countries.csv' as the new filename
+      hdxcli dictionary --project my_proj files download countries.csv --output ./data/countries.csv
+    """
+    profile = ctx.parent.obj["usercontext"]
+    resource_path = ctx.parent.obj["resource_path"]
+    download_dictionary_file(profile, resource_path, dictionary_filename, output_path)
+
+
+@click.command(cls=HdxCommand, name="delete")
+@click.argument("file_name", metavar="FILE_NAME")
+@click.pass_context
+@report_error_and_exit(exctype=Exception)
+def delete(ctx: click.Context, file_name: str):
+    """Delete a dictionary data file.
+
+    \b
+    Examples:
+      # Delete the file named 'my_dictionary_file'
+      hdxcli dictionary --project my_project files delete my_dictionary_file
+    """
+    profile = ctx.parent.obj["usercontext"]
+    resource_path = ctx.parent.obj["resource_path"]
+    hostname = profile.hostname
+    scheme = profile.scheme
+    resource_url = f"{scheme}://{hostname}{resource_path}/{file_name}"
+    basic_delete(profile, resource_path, file_name, url=resource_url)
+    logger.info(f"Deleted dictionary file {file_name}")
+
+
+files_group.add_command(upload)
+files_group.add_command(download)
+files_group.add_command(delete)
+files_group.add_command(command_list)

--- a/tests/command_line_interface/test_cases/test_read_only_flows.toml
+++ b/tests/command_line_interface/test_cases/test_read_only_flows.toml
@@ -35,7 +35,7 @@ global_setup = ["python3 -m hdx_cli.main project create test_ci_project",
                 "python3 -m hdx_cli.main transform --project test_ci_project --table test_ci_table_zip create -f {HDXCLI_TESTS_DIR}/tests_data/transforms/zip_transform.json test_zip_transform",
                 "python3 -m hdx_cli.main transform --project test_ci_project --table test_ci_table_zlib create -f {HDXCLI_TESTS_DIR}/tests_data/transforms/zlib_transform.json test_zlib_transform",
                 "python3 -m hdx_cli.main view --project test_ci_project --table test_ci_table create -f {HDXCLI_TESTS_DIR}/tests_data/views/view_settings.json test_ci_view",
-                "python3 -m hdx_cli.main dictionary --project test_ci_project files upload -t verbatim {HDXCLI_TESTS_DIR}/tests_data/dictionaries/dictionary_file.csv test_ci_dictionary_file",
+                "python3 -m hdx_cli.main dictionary --project test_ci_project files upload {HDXCLI_TESTS_DIR}/tests_data/dictionaries/dictionary_file.csv test_ci_dictionary_file",
                 "python3 -m hdx_cli.main dictionary --project test_ci_project create {HDXCLI_TESTS_DIR}/tests_data/dictionaries/dictionary_settings.json test_ci_dictionary_file test_ci_dictionary",
                 # "python3 -m hdx_cli.main job batch --project test_ci_project --table test_ci_table ingest test_ci_batch_job {HDXCLI_TESTS_DIR}/tests_data/batch-jobs/batch_job_ci_settings.json",
                 # "python3 -m hdx_cli.main sources kafka --project test_ci_project --table test_ci_table create {HDXCLI_TESTS_DIR}/tests_data/sources/kafka_source_settings.json test_ci_kafka_source",
@@ -718,16 +718,24 @@ expected_output_expr = '"name" in result and "test_ci_dictionary" in result and 
 
 ################################################### Dictionary Files #####################################################
 [[test]]
-name = "Dictionary files can be uploaded"
+name = "Dictionary files can be uploaded - .csv format"
 setup = ["python3 -m hdx_cli.main set test_ci_project"]
-commands_under_test = ["python3 -m hdx_cli.main dictionary files upload -t verbatim {HDXCLI_TESTS_DIR}/tests_data/dictionaries/dictionary_file.csv test_dictionary_file"]
-teardown = ["python3 -m hdx_cli.main dictionary files delete test_dictionary_file",
+commands_under_test = ["python3 -m hdx_cli.main dictionary files upload {HDXCLI_TESTS_DIR}/tests_data/dictionaries/dictionary_file.csv test_csv_file"]
+teardown = ["python3 -m hdx_cli.main dictionary files delete test_csv_file",
             "python3 -m hdx_cli.main unset"]
-expected_output = 'Uploaded dictionary file test_dictionary_file'
+expected_output = 'Uploaded dictionary file test_csv_file'
+
+[[test]]
+name = "Dictionary files can be uploaded - .json format"
+setup = ["python3 -m hdx_cli.main set test_ci_project"]
+commands_under_test = ["python3 -m hdx_cli.main dictionary files upload {HDXCLI_TESTS_DIR}/tests_data/dictionaries/dictionary_file.json test_json_file"]
+teardown = ["python3 -m hdx_cli.main dictionary files delete test_json_file",
+            "python3 -m hdx_cli.main unset"]
+expected_output = 'Uploaded dictionary file test_json_file'
 
 [[test]]
 name = "Dictionary files can be deleted"
-setup = ["python3 -m hdx_cli.main dictionary --project test_ci_project files upload -t verbatim {HDXCLI_TESTS_DIR}/tests_data/dictionaries/dictionary_file.csv test_dictionary_file"]
+setup = ["python3 -m hdx_cli.main dictionary --project test_ci_project files upload {HDXCLI_TESTS_DIR}/tests_data/dictionaries/dictionary_file.csv test_dictionary_file"]
 commands_under_test = ["python3 -m hdx_cli.main dictionary --project test_ci_project files delete test_dictionary_file"]
 expected_output = 'Deleted dictionary file test_dictionary_file'
 
@@ -740,6 +748,15 @@ expected_output_re = '.*?test_ci_dictionary_file.*'
 name = "Dictionary file can be downloaded"
 commands_under_test = ["python3 -m hdx_cli.main dictionary --project test_ci_project files download test_ci_dictionary_file"]
 expected_output_re = '.*?Dictionary file saved to:*.'
+
+[[test]]
+name = "A dictionary file can be updated for a new file"
+setup = ["python3 -m hdx_cli.main set test_ci_project",
+         "python3 -m hdx_cli.main dictionary files upload {HDXCLI_TESTS_DIR}/tests_data/dictionaries/dictionary_file.csv test_dict_file"]
+commands_under_test = ["python3 -m hdx_cli.main dictionary files update {HDXCLI_TESTS_DIR}/tests_data/dictionaries/dictionary_file.json test_dict_file --yes"]
+teardown = ["python3 -m hdx_cli.main dictionary files delete test_dict_file",
+            "python3 -m hdx_cli.main unset"]
+expected_output_re = '.*?Successfully updated dictionary file*.'
 
 
 ######################################################## Role ##########################################################

--- a/tests/command_line_interface/tests_data/dictionaries/dictionary_file.json
+++ b/tests/command_line_interface/tests_data/dictionaries/dictionary_file.json
@@ -1,0 +1,19 @@
+[
+    {
+        "id": 1,
+        "country": "Spain"
+    },
+    {
+        "id": 2,
+        "country": "England"
+    },
+    {
+        "id": 3,
+        "country": "France"
+    },
+    {
+        "id": 4,
+        "country": "Germany"
+    }
+]
+


### PR DESCRIPTION
This PR introduces two primary enhancements to the dictionary files command set:
- Adds a new `update` command, which streamlines the workflow for replacing an existing dictionary file by combining delete and upload operations into a single command.
- Deprecates the `--body-from-file-type` option in the existing upload command. The option is now hidden from the `--help` output. It remains operational to ensure backward compatibility for existing scripts and will display a warning message if used.

Here the `--help` of the new `update` command for more information:

```shell
hdxcli dictionary files update --help
Usage: hdxcli dictionary files update [OPTIONS] LOCAL_FILE_PATH
                                      REMOTE_FILE_NAME

  Updates an existing dictionary data file by replacing it.

  This command provides a convenient way to replace a remote dictionary file
  with a local version in a single step. It first deletes the existing remote
  file and then uploads the new one.

  The command can be run in two modes:
   - INTERACTIVE: If `REMOTE_FILE_NAME` is not provided, you will be
     prompted to select from a list of existing files.
   - DIRECT: If `REMOTE_FILE_NAME` is provided, the command will target
     that file directly. For safety, a confirmation prompt is still
     shown unless the `--yes` flag is used.

  Examples:
    # Interactively update a dictionary file in the 'my_project' project
    hdxcli dictionary --project my_project files update ./new_countries.csv

    # Directly update 'countries' file after asking for confirmation
    hdxcli dictionary --project my_project files update ./new_countries.csv countries

    # Directly update 'cities' file without any prompts
    hdxcli dictionary --project my_project files update ./new_cities.json cities --yes

Options:
  -y, --yes  Skip the confirmation prompt and proceed with the update.
  --help     Show this message and exit.
``` 